### PR TITLE
Add entry points to setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,14 @@ $RECYCLE.BIN/
 Network Trash Folder
 Temporary Items
 .apdisk
+
+xrt.egg-info/
+xrt/gui/commons/.buildinfo
+xrt/gui/commons/_sources/
+xrt/gui/commons/_static/
+xrt/gui/commons/doctrees/
+xrt/gui/commons/genindex.html
+xrt/gui/commons/objects.inv
+xrt/gui/commons/search.html
+xrt/gui/commons/searchindex.js
+xrt/gui/commons/xrtQookPage.html

--- a/setup.py
+++ b/setup.py
@@ -206,6 +206,7 @@ setup(
         'xrt.gui.xrtQook': ['_icons/*.*'],
         'xrt.gui.xrtGlow': ['_icons/*.*']},
     scripts=['xrt/gui/xrtQookStart.pyw', 'xrt/gui/xrtQookStart.py'],
+    entry_points={'console_scripts': ['xrt = xrt.gui.xrtQookStart:main']},
     install_requires=['numpy>=1.8.0', 'scipy>=0.17.0', 'matplotlib>=2.0.0',
                       'sphinx>=1.6.2',
                       # 'openpyxl', 'distro'

--- a/xrt/gui/xrtQookStart.py
+++ b/xrt/gui/xrtQookStart.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """This script launches xrtQook."""
 __author__ = "Roman Chernikov, Konstantin Klementiev"

--- a/xrt/gui/xrtQookStart.py
+++ b/xrt/gui/xrtQookStart.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.join('..', '..'))
 import xrt.gui.xrtQook as xQ
 
 
-if __name__ == '__main__':
+def main():
     if any('spyder' in name.lower() for name in os.environ):
         pass  # spyder is present
     else:
@@ -29,3 +29,7 @@ if __name__ == '__main__':
     ex.setWindowTitle("xrtQook")
     ex.show()
     sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()

--- a/xrt/gui/xrtQookStart.pyw
+++ b/xrt/gui/xrtQookStart.pyw
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """This script launches xrtQook."""
 __author__ = "Roman Chernikov, Konstantin Klementiev"


### PR DESCRIPTION
This PR adds the `entry_points` field to `setup.py` to allow an easy access to the xrt GUI via a command line, i.e. by simple typing of `xrt` after the installation one will get the `xrtQook` GUI running.

Maybe the `scripts` field won't be needed anymore: https://github.com/kklmn/xrt/blob/75b884c0cba7e1aac15b30f2d0d803597328a208/setup.py#L206