### PR TITLE
Capture custom `pyopencl._cl.LogicError` exception on importing of `pyopencl`

### DIFF
--- a/xrt/backends/raycing/myopencl.py
+++ b/xrt/backends/raycing/myopencl.py
@@ -16,7 +16,7 @@ try:
     cl.get_platforms()
     os.environ['PYOPENCL_COMPILER_OUTPUT'] = '1'
     isOpenCL = True
-except ImportError:
+except Exception:
     isOpenCL = False
 
 try:


### PR DESCRIPTION
Error on a Windows build/test in https://github.com/conda-forge/xrt-feedstock/pull/5 ([build log](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=380485&view=logs&j=171a126d-c574-5c8c-1269-ff3b989e923d&t=1183ba29-a0b5-5324-8463-2a49ace9e213&l=967)):
```py
pyopencl._cl.LogicError: clGetPlatformIDs failed: PLATFORM_NOT_FOUND_KHR
```

Discussed that issue with @yxrmz over DM, and the wider `Exception` helped to eliminate the issue, as the original `ImportError` did not capture the above exception.