### PR TITLE
prevent Qt driven crashes

### DIFF
--- a/xrt/backends/raycing/__init__.py
+++ b/xrt/backends/raycing/__init__.py
@@ -1187,7 +1187,9 @@ class BeamLine(object):
         from .run import run_process
         run_process(self)
         if self.blViewer is None:
-            app = xrtglow.qt.QApplication(sys.argv)
+            app = xrtglow.qt.QApplication.instance()
+            if app is None:
+                app = xrtglow.qt.QApplication(sys.argv)
             rayPath = self.export_to_glow()
             self.blViewer = xrtglow.xrtGlow(rayPath)
             self.blViewer.generator = generator

--- a/xrt/gui/commons/qt.py
+++ b/xrt/gui/commons/qt.py
@@ -180,4 +180,7 @@ class QComboBox(StdQComboBox):
         if self.hasFocus():
             return StdQComboBox.wheelEvent(self, *args, **kwargs)
         else:
-            return self.parent().wheelEvent(*args, **kwargs)
+            try:
+                return self.parent().wheelEvent(*args, **kwargs)
+            except RuntimeError:
+                return


### PR DESCRIPTION
Two minor changes to handling things in Qt.  

I am also using a patch locally that lets me skip starting the event loop + sys.exit` is `.glow`, but I want to think about that a bit more and understand how it was meant to be used before I propose that!