### PR TITLE
MNT: explicitly allow pickle in np.load

### DIFF
--- a/xrt/gui/xrtGlow/__init__.py
+++ b/xrt/gui/xrtGlow/__init__.py
@@ -1499,7 +1499,7 @@ class xrtGlow(qt.QWidget):
 
     def loadScene(self, filename):
         try:
-            params = np.load(filename).item()
+            params = np.load(filename, allow_pickle=True).item()
         except:  # analysis:ignore
             print('Error loading file')
             return


### PR DESCRIPTION
Required in newer versions of numpy