### PR TITLE
Normalize GUI and runtime references to raycing objects

### DIFF
--- a/examples/withRaycing/02_Balder_BL/BalderBL.py
+++ b/examples/withRaycing/02_Balder_BL/BalderBL.py
@@ -61,7 +61,8 @@ def build_beamline(nrays=raycing.nrays, hkl=(1, 1, 1), stripe='Si',
     beamLine.fsm0 = rsc.Screen(beamLine, 'FSM0', (0, 15000, height))
     beamLine.feFixedMask = ra.RectangularAperture(
         beamLine, 'FEFixedMask', (0, 15750, height),
-        ('left', 'right', 'bottom', 'top'), [-3.15, 3.15, -0.7875, 0.7875])
+        blades={'left': -3.15, 'right': 3.15,
+                'bottom': -0.7875, 'top': 0.7875})
     beamLine.fsmFE = rsc.Screen(beamLine, 'FSM-FE', (0, 16000, height))
 
     beamLine.filter1 = roe.Plate(
@@ -92,11 +93,12 @@ def build_beamline(nrays=raycing.nrays, hkl=(1, 1, 1), stripe='Si',
         limPhysX2=(-10, 10), limPhysY2=(-90, 90), alarmLevel=0.)
 
     beamLine.BSBlock = ra.RectangularAperture(
-        beamLine, 'BSBlock', (0, 29100, height), ('bottom',),
-        (22,), alarmLevel=0.)
+        beamLine, 'BSBlock', (0, 29100, height),
+        blades={'bottom': 22}, alarmLevel=0.)
     beamLine.slitAfterDCM = ra.RectangularAperture(
         beamLine, 'SlitAfterDCM', (0, 29200, height),
-        ('left', 'right', 'bottom', 'top'), [-7, 7, -2, 2], alarmLevel=0.5)
+        blades={'left': -7, 'right': 7, 'bottom': -2, 'top': 2},
+        alarmLevel=0.5)
     beamLine.fsmDCM = rsc.Screen(beamLine, 'FSM-DCM', (0, 29400, height))
 
     beamLine.vfm = roe.SimpleVFM(
@@ -107,15 +109,18 @@ def build_beamline(nrays=raycing.nrays, hkl=(1, 1, 1), stripe='Si',
         positionRoll=math.pi, R=5.0e6, r=40.77, alarmLevel=0.2)
     beamLine.slitAfterVFM = ra.RectangularAperture(
         beamLine, 'SlitAfterVFM', (0, 31720, height),
-        ('left', 'right', 'bottom', 'top'), [-7, 7, -2, 2], alarmLevel=0.5)
+        blades={'left': -7, 'right': 7, 'bottom': -2, 'top': 2},
+        alarmLevel=0.5)
     beamLine.fsmVFM = rsc.Screen(beamLine, 'FSM-VFM', (0, 32000, height))
     beamLine.ohPS = ra.RectangularAperture(
         beamLine, 'OH-PS', (0, 32070, height),
-        ('left', 'right', 'bottom', 'top'), (-20, 20, 25, 55), alarmLevel=0.2)
+        blades={'left': -20, 'right': 20, 'bottom': 25, 'top': 55},
+        alarmLevel=0.2)
 
     beamLine.slitEH = ra.RectangularAperture(
         beamLine, 'slitEH', (0, 43000, height),
-        ('left', 'right', 'bottom', 'top'), [-20, 20, -7, 7], alarmLevel=0.5)
+        blades={'left': -20, 'right': 20, 'bottom': -7, 'top': 7},
+        alarmLevel=0.5)
     beamLine.fsmSample = rsc.Screen(
         beamLine, 'FSM-Sample', (0, 45863, height))
 
@@ -219,8 +224,7 @@ def align_beamline(beamLine, pitch=None, bragg=None, energy=9000.,
         beamLine.vfm.R = vfmR
     fefm = beamLine.feFixedMask
     op = fefm.center[1] * aceptanceV / 2 * min(1, pitch/2e-3)
-    fefm.opening[2] = -op
-    fefm.opening[3] = op
+    fefm.blades = dict(fefm.blades, bottom=-op, top=op)
 
     beamLine.vcm.pitch = pitch
     p = raycing.distance_xy(beamLine.vcm.center, beamLine.sources[0].center)
@@ -274,10 +278,11 @@ def align_beamline(beamLine, pitch=None, bragg=None, energy=9000.,
         beamLine.vfm.center,
         (beamLine.slitAfterDCM.center[0], beamLine.slitAfterDCM.center[1]))
     slitHeight = heightVFM - p * math.tan(2 * pitch)
-    dz = beamLine.slitAfterDCM.opening[3] - beamLine.slitAfterDCM.opening[2]
-    beamLine.slitAfterDCM.opening[2] = slitHeight - beamLine.height - dz/2
-    beamLine.slitAfterDCM.opening[3] = slitHeight - beamLine.height + dz/2
-    beamLine.slitAfterDCM.set_optical_limits()
+    blades = beamLine.slitAfterDCM.blades
+    dz = blades['top'] - blades['bottom']
+    beamLine.slitAfterDCM.blades = dict(
+        blades, bottom=slitHeight - beamLine.height - dz/2,
+        top=slitHeight - beamLine.height + dz/2)
 
     p = raycing.distance_xy(beamLine.vfm.center, beamLine.fsmDCM.center)
     fsmHeight = heightVFM - p * math.tan(2 * pitch)
@@ -292,10 +297,11 @@ def align_beamline(beamLine, pitch=None, bragg=None, energy=9000.,
     print('VFM.R = {0:.0f}'.format(beamLine.vfm.R))
     print('VFM.r = {0:.3f}'.format(beamLine.vfm.r))
 
-    dz = beamLine.slitAfterVFM.opening[3] - beamLine.slitAfterVFM.opening[2]
-    beamLine.slitAfterVFM.opening[2] = heightVFM - beamLine.height - dz/2
-    beamLine.slitAfterVFM.opening[3] = heightVFM - beamLine.height + dz/2
-    beamLine.slitAfterVFM.set_optical_limits()
+    blades = beamLine.slitAfterVFM.blades
+    dz = blades['top'] - blades['bottom']
+    beamLine.slitAfterVFM.blades = dict(
+        blades, bottom=heightVFM - beamLine.height - dz/2,
+        top=heightVFM - beamLine.height + dz/2)
 
     p = raycing.distance_xy(beamLine.vfm.center, beamLine.sources[0].center)
     q = 1./(2 * np.sin(pitch)/beamLine.vfm.r - 1./p)
@@ -307,12 +313,12 @@ def align_beamline(beamLine, pitch=None, bragg=None, energy=9000.,
         (beamLine.slitEH.center[0], beamLine.slitEH.center[1]),
         beamLine.vfm.center)
     s = abs(1. - qr / q) * p * aceptanceH / 2
-    beamLine.slitEH.opening[0] = -s * 1.2
-    beamLine.slitEH.opening[1] = s * 1.2
-    dz = beamLine.slitEH.opening[3] - beamLine.slitEH.opening[2]
-    beamLine.slitEH.opening[2] = heightVFM - beamLine.height - dz/2
-    beamLine.slitEH.opening[3] = heightVFM - beamLine.height + dz/2
-    beamLine.slitEH.set_optical_limits()
+    blades = beamLine.slitEH.blades
+    dz = blades['top'] - blades['bottom']
+    beamLine.slitEH.blades = dict(
+        blades, left=-s * 1.2, right=s * 1.2,
+        bottom=heightVFM - beamLine.height - dz/2,
+        top=heightVFM - beamLine.height + dz/2)
 
 
 if __name__ == '__main__':

--- a/examples/withRaycing/02_Balder_BL/traceBalderBL.py
+++ b/examples/withRaycing/02_Balder_BL/traceBalderBL.py
@@ -163,8 +163,8 @@ def define_plots(beamLine, prefix, suffix):
         caxis='category', title=beamLine.BSBlock.name, oe=beamLine.BSBlock)
     add_plot(plots, plot, prefix, suffix)
 
-    op = beamLine.slitAfterDCM.opening
-    cz = (op[2] + op[3]) / 2
+    blades = beamLine.slitAfterDCM.blades
+    cz = (blades['bottom'] + blades['top']) / 2
     plot = xrtp.XYCPlot(
         'beamSlitAfterDCMlocal', (1, 2, beamLine.slitAfterDCM.lostNum),
         xaxis=xrtp.XYCAxis(r'$x$', 'mm', limits=[-8, 8]),
@@ -180,8 +180,8 @@ def define_plots(beamLine, prefix, suffix):
         caxis='category', title='VFM_footprint', oe=beamLine.vfm)
     add_plot(plots, plot, prefix, suffix)
 
-    op = beamLine.slitAfterVFM.opening
-    cz = (op[2] + op[3]) / 2
+    blades = beamLine.slitAfterVFM.blades
+    cz = (blades['bottom'] + blades['top']) / 2
     plot = xrtp.XYCPlot(
         'beamSlitAfterVFMlocal', (1, 2, beamLine.slitAfterVFM.lostNum),
         xaxis=xrtp.XYCAxis(r'$x$', 'mm', limits=[-8, 8]),
@@ -197,9 +197,9 @@ def define_plots(beamLine, prefix, suffix):
         caxis='category', title=beamLine.ohPS.name, oe=beamLine.ohPS)
     add_plot(plots, plot, prefix, suffix)
 #
-    op = beamLine.slitEH.opening
-    cz = (op[2] + op[3]) / 2
-    dx = (op[1] - op[0]) / 2
+    blades = beamLine.slitEH.blades
+    cz = (blades['bottom'] + blades['top']) / 2
+    dx = (blades['right'] - blades['left']) / 2
     plot = xrtp.XYCPlot(
         'beamSlitEHLocal', (1, 2, beamLine.slitEH.lostNum),
         xaxis=xrtp.XYCAxis(r'$x$', 'mm', limits=[-dx, dx]),

--- a/examples/withRaycing/06_AnalyzerBent1D/01L_SourceZCrystalThetaAlpha.py
+++ b/examples/withRaycing/06_AnalyzerBent1D/01L_SourceZCrystalThetaAlpha.py
@@ -14,8 +14,11 @@ switch off/on the corresponding angles or crystals. The source sizes, axis
 limits, number of iterations etc. were determined experimentally and are given
 by lists in the upper part of the script. The outputs are the plots and a text
 file with the resulted energy resolutions."""
+
 __author__ = "Konstantin Klementiev"
 __date__ = "08 Mar 2016"
+
+
 import os, sys; sys.path.append(os.path.join('..', '..', '..'))  # analysis:ignore
 import math
 import numpy as np
@@ -507,8 +510,8 @@ def main():
         return
     plots, plotsAnalyzer, plotsDetector, plotsE, plotAnE, plotDetE =\
         define_plots(beamLine)
-    args = [plots, plotsAnalyzer, plotsDetector, plotsE, plotAnE, plotDetE,
-            beamLine]
+    args = [beamLine, plots, plotsAnalyzer, plotsDetector, plotsE, plotAnE,
+            plotDetE]
     xrtr.run_ray_tracing(
         plots, generator=plot_generator, generatorArgs=args,
         beamLine=beamLine, processes='half')

--- a/tests/raycing/auto/test_property_apertures.py
+++ b/tests/raycing/auto/test_property_apertures.py
@@ -82,6 +82,21 @@ class AperturePropertyRoundTripTest(unittest.TestCase):
 
         assert_equivalent(self, aperture.blades, {'left': -1., 'right': 1.})
 
+    def test_rectangular_in_place_opening_update_refreshes_blades(self):
+        aperture = rapts.RectangularAperture(
+            bl=raycing.BeamLine(), name='slit',
+            kind=['left', 'right', 'bottom', 'top'],
+            opening=[-1., 1., -2., 2.])
+
+        aperture.opening[2] = 4.
+        aperture.opening[3] = 8.
+        aperture.set_optical_limits()
+
+        assert_equivalent(
+            self, aperture.blades,
+            {'left': -1., 'right': 1., 'bottom': 4., 'top': 8.})
+        assert_equivalent(self, aperture.limOptY, [4., 8.])
+
     def test_rectangular_opening_dict_updates_blades(self):
         aperture = rapts.RectangularAperture(
             bl=raycing.BeamLine(), name='slit',

--- a/tests/raycing/auto/test_property_beamline.py
+++ b/tests/raycing/auto/test_property_beamline.py
@@ -11,6 +11,8 @@ if _XRT_ROOT not in sys.path:
     sys.path.insert(0, _XRT_ROOT)  # analysis:ignore
 
 from xrt.backends import raycing
+from xrt.backends.raycing import materials as rmats
+from xrt.backends.raycing import oes as roes
 
 from tests.raycing.auto._property_test_helpers import (
     assert_equivalent, assert_metadata_contract, assert_plain_roundtrip)
@@ -80,6 +82,21 @@ class BeamLinePropertyRoundTripTest(unittest.TestCase):
                 'beamNamesDict'):
             with self.subTest(attr=attr):
                 assert_equivalent(self, dict(getattr(beamline, attr)), {})
+
+
+class BeamLineReferenceIndexingTest(unittest.TestCase):
+    def test_index_materials_keeps_refractive_uuid_safe(self):
+        material = rmats.Material(
+            elements='C', quantities=[1], rho=3.52, kind='plate', name='CVD')
+        beamline = raycing.BeamLine(name='bl')
+        plate = roes.Plate(
+            bl=beamline, name='plate', material=material, t=1.)
+
+        beamline.index_materials()
+
+        self.assertEqual(plate._material, material.uuid)
+        self.assertIs(plate.material, material)
+        self.assertIs(beamline.materialsDict[material.uuid], material)
 
 
 if __name__ == '__main__':

--- a/tests/raycing/auto/test_property_fes.py
+++ b/tests/raycing/auto/test_property_fes.py
@@ -100,7 +100,8 @@ class FigureErrorReferencePropertyTest(unittest.TestCase):
         fe = rfe.Waviness(name='wave', bl=bl, **FE_BASE_KWARGS)
 
         assert_reference_roundtrip(
-            self, fe, 'baseFE', bl, 'figureError', refs['base_fe'])
+            self, fe, 'baseFE', bl, 'figureError', refs['base_fe'],
+            direct_object_forms=('object', 'uuid', 'name'))
 
 
 if __name__ == '__main__':

--- a/tests/raycing/auto/test_property_materials.py
+++ b/tests/raycing/auto/test_property_materials.py
@@ -77,18 +77,22 @@ class MaterialReferencePropertyTest(unittest.TestCase):
         multilayer = rmats.Multilayer(name='ml', bl=bl)
 
         assert_reference_roundtrip(
-            self, multilayer, 'tLayer', bl, 'material', refs['water'])
+            self, multilayer, 'tLayer', bl, 'material', refs['water'],
+            direct_object_forms=('object', 'uuid', 'name'))
         assert_reference_roundtrip(
-            self, multilayer, 'bLayer', bl, 'material', refs['silicon'])
+            self, multilayer, 'bLayer', bl, 'material', refs['silicon'],
+            direct_object_forms=('object', 'uuid', 'name'))
         assert_reference_roundtrip(
-            self, multilayer, 'substrate', bl, 'material', refs['water'])
+            self, multilayer, 'substrate', bl, 'material', refs['water'],
+            direct_object_forms=('object', 'uuid', 'name'))
 
     def test_coated_coating_reference_forms(self):
         bl, refs = make_reference_beamline()
         coated = rmats.Coated(name='coated', bl=bl)
 
         assert_reference_roundtrip(
-            self, coated, 'coating', bl, 'material', refs['silicon'])
+            self, coated, 'coating', bl, 'material', refs['silicon'],
+            direct_object_forms=('object', 'uuid', 'name'))
 
     def test_txm_materials_index_reference_forms(self):
         bl, refs = make_reference_beamline()

--- a/tests/raycing/auto/test_property_oes.py
+++ b/tests/raycing/auto/test_property_oes.py
@@ -100,21 +100,24 @@ class OEReferencePropertyTest(unittest.TestCase):
         oe = roes.OE(bl=bl, name='oe')
 
         assert_reference_roundtrip(
-            self, oe, 'material', bl, 'material', refs['water'])
+            self, oe, 'material', bl, 'material', refs['water'],
+            direct_object_forms=('object', 'uuid', 'name'))
 
     def test_oe_figure_error_reference_forms(self):
         bl, refs = make_reference_beamline()
         oe = roes.OE(bl=bl, name='oe')
 
         assert_reference_roundtrip(
-            self, oe, 'figureError', bl, 'figureError', refs['bump'])
+            self, oe, 'figureError', bl, 'figureError', refs['bump'],
+            direct_object_forms=('object', 'uuid', 'name'))
 
     def test_dcm_material2_reference_forms(self):
         bl, refs = make_reference_beamline()
         dcm = roes.DCM(bl=bl, name='dcm')
 
         assert_reference_roundtrip(
-            self, dcm, 'material2', bl, 'material', refs['silicon'])
+            self, dcm, 'material2', bl, 'material', refs['silicon'],
+            direct_object_forms=('object', 'uuid', 'name'))
 
     def test_plate_material_reference_forms(self):
         bl, refs = make_reference_beamline()

--- a/tests/raycing/test_flow_utils.py
+++ b/tests/raycing/test_flow_utils.py
@@ -131,6 +131,15 @@ class ReferenceNormalizationTest(unittest.TestCase):
             normalize_ref(OE_UUID, self.bl, 'oe', 'object'),
             self.bl.oe)
 
+    def test_normalize_ref_unknown_uuid_object_defaults_to_none(self):
+        unknown_uuid = '99999999-9999-4999-8999-999999999999'
+
+        self.assertIsNone(
+            normalize_ref(unknown_uuid, self.bl, 'material', 'object'))
+        self.assertEqual(
+            normalize_ref(unknown_uuid, None, 'material', 'object'),
+            unknown_uuid)
+
     def test_normalize_ref_rejects_unknown_kind_or_target(self):
         with self.assertRaises(KeyError):
             normalize_ref('Water', self.bl, 'beam', 'uuid')

--- a/tests/raycing/test_flow_utils.py
+++ b/tests/raycing/test_flow_utils.py
@@ -1,0 +1,266 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from collections import OrderedDict
+
+from xrt.backends.raycing._flow_utils import (
+    create_paramdict_fe, create_paramdict_mat, create_paramdict_oe,
+    get_init_kwargs, normalize_ref, ref_kind_for_arg)
+
+
+WATER_UUID = '11111111-1111-4111-8111-111111111111'
+SILICON_UUID = '22222222-2222-4222-8222-222222222222'
+FE_UUID = '33333333-3333-4333-8333-333333333333'
+BASE_FE_UUID = '44444444-4444-4444-8444-444444444444'
+OE_UUID = '55555555-5555-4555-8555-555555555555'
+
+
+class RefObject:
+    def __init__(self, name, uuid):
+        self.name = name
+        self.uuid = uuid
+
+
+class FakeBeamLine:
+    def __init__(self):
+        self.water = RefObject('Water', WATER_UUID)
+        self.silicon = RefObject('Silicon', SILICON_UUID)
+        self.figureError = RefObject('Figure map', FE_UUID)
+        self.baseFE = RefObject('Base figure map', BASE_FE_UUID)
+        self.oe = RefObject('Mirror', OE_UUID)
+
+        self.materialsDict = OrderedDict([
+            (WATER_UUID, self.water),
+            (SILICON_UUID, self.silicon),
+        ])
+        self.matnamesToUUIDs = {
+            self.water.name: WATER_UUID,
+            self.silicon.name: SILICON_UUID,
+        }
+        self.fesDict = OrderedDict([
+            (FE_UUID, self.figureError),
+            (BASE_FE_UUID, self.baseFE),
+        ])
+        self.fenamesToUUIDs = {
+            self.figureError.name: FE_UUID,
+            self.baseFE.name: BASE_FE_UUID,
+        }
+        self.oesDict = OrderedDict([(OE_UUID, [self.oe, 1])])
+        self.oenamesToUUIDs = {self.oe.name: OE_UUID}
+
+
+class FakeOEForInitKwargs:
+    def __init__(self, name='', material=None, material2=None,
+                 figureError=None, center=None, beam=None, bl=None):
+        self.name = name
+        self.material = material
+        self.material2 = material2
+        self.figureError = figureError
+        self.center = center
+        self.beam = beam
+        self.bl = bl
+
+
+class FakeMaterialForInitKwargs:
+    def __init__(self, name='', tLayer=None, bLayer=None, coating=None,
+                 substrate=None, materialsIndex=None):
+        self.name = name
+        self.tLayer = tLayer
+        self.bLayer = bLayer
+        self.coating = coating
+        self.substrate = substrate
+        self.materialsIndex = materialsIndex
+
+
+class FakeFEForInitKwargs:
+    def __init__(self, name='', baseFE=None):
+        self.name = name
+        self.baseFE = baseFE
+
+
+class ReferenceNormalizationTest(unittest.TestCase):
+    def setUp(self):
+        self.bl = FakeBeamLine()
+
+    def test_ref_kind_for_arg_recognizes_reference_fields(self):
+        material_fields = [
+            'material', 'material2', 'tLayer', 'bLayer', 'coating',
+            'substrate', 'materialsIndex']
+        for field in material_fields:
+            self.assertEqual(ref_kind_for_arg(field), 'material')
+
+        for field in ['figureError', 'baseFE']:
+            self.assertEqual(ref_kind_for_arg(field), 'figureError')
+
+        for field in ['beam', 'beamLocal', 'center', 'limPhysX']:
+            self.assertIsNone(ref_kind_for_arg(field))
+
+    def test_normalize_ref_converts_material_refs_recursively(self):
+        value = OrderedDict([
+            ('same-key', self.bl.water),
+            ('name', 'Silicon'),
+            ('uuid', WATER_UUID),
+            ('none', None),
+            ('unknown', 'Unknown material'),
+            ('nested', [self.bl.silicon, 'Water']),
+        ])
+
+        normalized = normalize_ref(
+            value, self.bl, 'material', target='uuid')
+
+        self.assertEqual(list(normalized.keys()), list(value.keys()))
+        self.assertEqual(normalized['same-key'], WATER_UUID)
+        self.assertEqual(normalized['name'], SILICON_UUID)
+        self.assertEqual(normalized['uuid'], WATER_UUID)
+        self.assertIsNone(normalized['none'])
+        self.assertEqual(normalized['unknown'], 'Unknown material')
+        self.assertEqual(normalized['nested'], [SILICON_UUID, WATER_UUID])
+
+    def test_normalize_ref_can_make_display_names_and_objects(self):
+        self.assertEqual(
+            normalize_ref(WATER_UUID, self.bl, 'material', 'display'),
+            'Water')
+        self.assertEqual(
+            normalize_ref(self.bl.figureError, self.bl, 'figureError',
+                          'display'),
+            'Figure map')
+        self.assertIs(
+            normalize_ref('Mirror', self.bl, 'oe', 'object'),
+            self.bl.oe)
+        self.assertIs(
+            normalize_ref(OE_UUID, self.bl, 'oe', 'object'),
+            self.bl.oe)
+
+    def test_normalize_ref_rejects_unknown_kind_or_target(self):
+        with self.assertRaises(KeyError):
+            normalize_ref('Water', self.bl, 'beam', 'uuid')
+        with self.assertRaises(ValueError):
+            normalize_ref('Water', self.bl, 'material', 'path')
+
+
+class CreateParamdictTest(unittest.TestCase):
+    def setUp(self):
+        self.bl = FakeBeamLine()
+
+    def test_create_paramdict_oe_normalizes_references_but_not_beams(self):
+        def_args = {
+            'material': None,
+            'material2': None,
+            'figureError': None,
+            'center': None,
+            'beam': None,
+            'bl': None,
+        }
+        param_dict = {
+            'material': 'Water',
+            'material2': '[Water, Silicon]',
+            'figureError': 'Figure map',
+            'center': '[1, 2, auto]',
+            'beam': 'screen_global',
+            'bl': 'bl',
+        }
+
+        kwargs = create_paramdict_oe(param_dict, def_args, self.bl)
+
+        self.assertEqual(kwargs['material'], WATER_UUID)
+        self.assertEqual(kwargs['material2'], [WATER_UUID, SILICON_UUID])
+        self.assertEqual(kwargs['figureError'], FE_UUID)
+        self.assertEqual(kwargs['center'], [1, 2, 'auto'])
+        self.assertEqual(kwargs['beam'], 'screen_global')
+        self.assertIs(kwargs['bl'], self.bl)
+
+    def test_create_paramdict_mat_normalizes_layers_and_materials_index(self):
+        def_args = {
+            'tLayer': None,
+            'bLayer': None,
+            'substrate': None,
+            'materialsIndex': None,
+            'rho': 0,
+        }
+        param_dict = {
+            'tLayer': 'Water',
+            'bLayer': SILICON_UUID,
+            'substrate': 'None',
+            'materialsIndex':
+                "{0: 'Water', 1: '%s', 2: None}" % SILICON_UUID,
+            'rho': '2.33',
+        }
+
+        kwargs = create_paramdict_mat(param_dict, def_args, self.bl)
+
+        self.assertEqual(kwargs['tLayer'], WATER_UUID)
+        self.assertEqual(kwargs['bLayer'], SILICON_UUID)
+        self.assertNotIn('substrate', kwargs)
+        self.assertEqual(kwargs['materialsIndex'], {
+            0: WATER_UUID,
+            1: SILICON_UUID,
+            2: None,
+        })
+        self.assertEqual(kwargs['rho'], 2.33)
+
+    def test_create_paramdict_fe_normalizes_base_fe(self):
+        kwargs = create_paramdict_fe(
+            {'baseFE': 'Base figure map', 'scale': '3.5'},
+            {'baseFE': None, 'scale': 1.},
+            self.bl)
+
+        self.assertEqual(kwargs['baseFE'], BASE_FE_UUID)
+        self.assertEqual(kwargs['scale'], 3.5)
+
+
+class GetInitKwargsTest(unittest.TestCase):
+    def setUp(self):
+        self.bl = FakeBeamLine()
+
+    def test_get_init_kwargs_serializes_oe_references_to_uuids(self):
+        obj = FakeOEForInitKwargs(
+            name='oe',
+            material=self.bl.water,
+            material2=[self.bl.water, self.bl.silicon],
+            figureError=self.bl.figureError,
+            center=[0, 0, 0],
+            beam='screen_global',
+            bl=self.bl)
+
+        kwargs = get_init_kwargs(obj, compact=False, blname='bl')
+
+        self.assertEqual(kwargs['material'], WATER_UUID)
+        self.assertEqual(kwargs['material2'], str([WATER_UUID, SILICON_UUID]))
+        self.assertEqual(kwargs['figureError'], FE_UUID)
+        self.assertEqual(kwargs['beam'], 'screen_global')
+        self.assertEqual(kwargs['bl'], 'bl')
+
+    def test_get_init_kwargs_serializes_material_references_to_uuids(self):
+        obj = FakeMaterialForInitKwargs(
+            name='ml',
+            tLayer=self.bl.water,
+            bLayer='Silicon',
+            substrate=None,
+            materialsIndex={
+                0: self.bl.water,
+                1: 'Silicon',
+                2: None,
+            })
+        obj.bl = self.bl
+
+        kwargs = get_init_kwargs(obj, compact=False)
+
+        self.assertEqual(kwargs['tLayer'], WATER_UUID)
+        self.assertEqual(kwargs['bLayer'], SILICON_UUID)
+        self.assertEqual(kwargs['substrate'], 'None')
+        self.assertEqual(kwargs['materialsIndex'], str({
+            0: WATER_UUID,
+            1: SILICON_UUID,
+            2: None,
+        }))
+
+    def test_get_init_kwargs_serializes_figure_error_references_to_uuids(self):
+        obj = FakeFEForInitKwargs(name='fe', baseFE=self.bl.baseFE)
+
+        kwargs = get_init_kwargs(obj, compact=False)
+
+        self.assertEqual(kwargs['baseFE'], BASE_FE_UUID)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/raycing/test_reference_bookkeeping.py
+++ b/tests/raycing/test_reference_bookkeeping.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from collections import OrderedDict
+
+from xrt.backends.raycing._flow import MessageHandler
+from xrt.backends.raycing.beamline import BeamLine
+
+
+WATER_UUID = '11111111-1111-4111-8111-111111111111'
+SILICON_UUID = '22222222-2222-4222-8222-222222222222'
+TXM_UUID = '33333333-3333-4333-8333-333333333333'
+FE_UUID = '44444444-4444-4444-8444-444444444444'
+BASE_FE_UUID = '55555555-5555-4555-8555-555555555555'
+OE_UUID = '66666666-6666-4666-8666-666666666666'
+HOLDER_UUID = '77777777-7777-4777-8777-777777777777'
+
+
+class RefObject:
+    def __init__(self, name, uuid, **kwargs):
+        self.name = name
+        self.uuid = uuid
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class FakeOE:
+    def __init__(self, name='oe', uuid=OE_UUID, material=None,
+                 material2=None, figureError=None):
+        self.name = name
+        self.uuid = uuid
+        self.material = material
+        self.material2 = material2
+        self.figureError = figureError
+        self._material = material
+        self._material2 = material2
+        self._figureError = figureError
+
+
+def make_beamline():
+    bl = BeamLine()
+    bl.water = RefObject('Water', WATER_UUID)
+    bl.silicon = RefObject('Silicon', SILICON_UUID)
+    bl.txm = RefObject('TXM', TXM_UUID)
+    bl.figureError = RefObject('Figure map', FE_UUID)
+    bl.baseFE = RefObject('Base figure map', BASE_FE_UUID)
+
+    bl.materialsDict = OrderedDict([
+        (WATER_UUID, bl.water),
+        (SILICON_UUID, bl.silicon),
+        (TXM_UUID, bl.txm),
+    ])
+    bl.matnamesToUUIDs = {
+        bl.water.name: WATER_UUID,
+        bl.silicon.name: SILICON_UUID,
+        bl.txm.name: TXM_UUID,
+    }
+    bl.fesDict = OrderedDict([
+        (FE_UUID, bl.figureError),
+        (BASE_FE_UUID, bl.baseFE),
+    ])
+    bl.fenamesToUUIDs = {
+        bl.figureError.name: FE_UUID,
+        bl.baseFE.name: BASE_FE_UUID,
+    }
+    bl.oesDict = OrderedDict()
+    return bl
+
+
+class BeamlineReferenceTest(unittest.TestCase):
+    def test_sort_materials_resolves_names_and_materials_index_values(self):
+        bl = make_beamline()
+        bl.materialsDict = OrderedDict([
+            (TXM_UUID, bl.txm),
+            (WATER_UUID, bl.water),
+            (SILICON_UUID, bl.silicon),
+        ])
+        bl.txm.materialsIndex = {
+            0: 'Water',
+            1: SILICON_UUID,
+            2: bl.silicon,
+        }
+
+        self.assertEqual(
+            bl.sort_materials(),
+            [WATER_UUID, SILICON_UUID, TXM_UUID])
+
+    def test_sort_figerrors_resolves_base_fe_name(self):
+        bl = make_beamline()
+        bl.fesDict = OrderedDict([
+            (FE_UUID, bl.figureError),
+            (BASE_FE_UUID, bl.baseFE),
+        ])
+        bl.figureError.baseFE = 'Base figure map'
+
+        self.assertEqual(
+            bl.sort_figerrors(),
+            [BASE_FE_UUID, FE_UUID])
+
+    def test_delete_material_clears_uuid_name_and_container_refs(self):
+        bl = make_beamline()
+        oe = FakeOE(material=WATER_UUID,
+                    material2=[SILICON_UUID, 'Water'])
+        holder = RefObject(
+            'Holder', HOLDER_UUID,
+            tLayer='Water',
+            bLayer=SILICON_UUID,
+            materialsIndex={0: WATER_UUID, 1: 'Silicon'})
+        bl.oesDict[OE_UUID] = [oe, 1]
+        bl.materialsDict[holder.uuid] = holder
+
+        bl.delete_mat_by_id(WATER_UUID)
+
+        self.assertNotIn(WATER_UUID, bl.materialsDict)
+        self.assertNotIn('Water', bl.matnamesToUUIDs)
+        self.assertIsNone(oe.material)
+        self.assertEqual(oe.material2, [SILICON_UUID, None])
+        self.assertIsNone(holder.tLayer)
+        self.assertEqual(holder.bLayer, SILICON_UUID)
+        self.assertEqual(holder.materialsIndex, {0: None, 1: 'Silicon'})
+
+    def test_delete_figure_error_clears_uuid_and_name_refs(self):
+        bl = make_beamline()
+        oe = FakeOE(figureError=FE_UUID)
+        bl.oesDict[OE_UUID] = [oe, 1]
+        bl.figureError.baseFE = 'Base figure map'
+
+        bl.delete_fe_by_id(BASE_FE_UUID)
+        self.assertNotIn(BASE_FE_UUID, bl.fesDict)
+        self.assertNotIn('Base figure map', bl.fenamesToUUIDs)
+        self.assertIsNone(bl.figureError.baseFE)
+
+        bl.delete_fe_by_id(FE_UUID)
+        self.assertIsNone(oe.figureError)
+
+    def test_index_materials_registers_nested_refs(self):
+        bl = make_beamline()
+        holder = RefObject(
+            'Holder', HOLDER_UUID,
+            tLayer='Water',
+            materialsIndex={0: 'Silicon'})
+        bl.figureError.baseFE = 'Base figure map'
+        oe = FakeOE(material=holder, figureError=bl.figureError)
+        bl.oesDict[OE_UUID] = [oe, 1]
+
+        bl.index_materials()
+
+        self.assertEqual(oe.material, HOLDER_UUID)
+        self.assertEqual(holder.tLayer, WATER_UUID)
+        self.assertIn(HOLDER_UUID, bl.materialsDict)
+        self.assertIn(WATER_UUID, bl.materialsDict)
+        self.assertIn(SILICON_UUID, bl.materialsDict)
+        self.assertEqual(oe.figureError, FE_UUID)
+        self.assertEqual(bl.figureError.baseFE, BASE_FE_UUID)
+
+
+class FlowReferenceTest(unittest.TestCase):
+    def test_modify_material_restarts_oe_that_refs_material_object(self):
+        bl = make_beamline()
+        oe = FakeOE(material=bl.water)
+        bl.oesDict[OE_UUID] = [oe, 1]
+        handler = MessageHandler(bl)
+
+        handler.handle_modify({
+            'object_type': 'mat',
+            'uuid': WATER_UUID,
+            'kwargs': {'name': 'Water updated'},
+        })
+
+        self.assertEqual(handler.startEl, OE_UUID)
+        self.assertTrue(handler.needUpdate)
+        self.assertEqual(bl.water.name, 'Water updated')
+
+    def test_delete_fe_restarts_oe_that_refs_figure_error_object(self):
+        bl = make_beamline()
+        oe = FakeOE(figureError=bl.figureError)
+        bl.oesDict[OE_UUID] = [oe, 1]
+        handler = MessageHandler(bl)
+
+        handler.handle_delete({
+            'object_type': 'fe',
+            'uuid': FE_UUID,
+        })
+
+        self.assertEqual(handler.startEl, OE_UUID)
+        self.assertTrue(handler.needUpdate)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/run_raycing_examples.py
+++ b/tests/run_raycing_examples.py
@@ -1,0 +1,448 @@
+# -*- coding: utf-8 -*-
+"""Run raycing example scripts with smoke-test tracing limits.
+
+This helper runs every selected example in a separate Python process. In the
+child process it patches :func:`xrt.runner.run_ray_tracing` so that scripted
+examples use a small, fixed number of rays and repeats while keeping each
+example's own initialization and generator setup code.
+
+Typical use from the repository root::
+
+    python tests/run_raycing_examples.py --nrays 10000 --repeats 1
+
+Use ``--list`` first when tuning include/exclude filters.
+"""
+
+from __future__ import print_function
+
+import argparse
+import ast
+import inspect
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import time
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_EXAMPLES = ROOT / "examples" / "withRaycing"
+
+
+class _ExampleSourceTransformer(ast.NodeTransformer):
+    """Small in-memory tweaks for examples that default to GUI mode."""
+
+    def __init__(self, force_no_3d=True, force_rays=False):
+        self.force_no_3d = force_no_3d
+        self.force_rays = force_rays
+
+    def visit_Module(self, node):
+        new_body = []
+        for stmt in node.body:
+            if self.force_no_3d and _assigns_name(stmt, "showIn3D"):
+                stmt = _replace_assignment_value(stmt, ast.Constant(False))
+            elif self.force_rays and _assigns_name(stmt, "what"):
+                stmt = _replace_assignment_value(stmt, ast.Constant("rays"))
+            new_body.append(stmt)
+        node.body = new_body
+        ast.fix_missing_locations(node)
+        return node
+
+
+def _assigns_name(stmt, name):
+    if isinstance(stmt, ast.Assign):
+        return any(isinstance(target, ast.Name) and target.id == name
+                   for target in stmt.targets)
+    if isinstance(stmt, ast.AnnAssign):
+        return isinstance(stmt.target, ast.Name) and stmt.target.id == name
+    return False
+
+
+def _replace_assignment_value(stmt, value):
+    if isinstance(stmt, ast.Assign):
+        return ast.Assign(targets=stmt.targets, value=value)
+    if isinstance(stmt, ast.AnnAssign):
+        return ast.AnnAssign(
+            target=stmt.target, annotation=stmt.annotation, value=value,
+            simple=stmt.simple)
+    return stmt
+
+
+def _as_list(value):
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        return list(value)
+    return [value]
+
+
+def _display_path(path, root=ROOT):
+    try:
+        return str(Path(path).resolve().relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _iter_example_scripts(paths, repo_root):
+    seen = set()
+    for raw_path in paths:
+        path = Path(raw_path)
+        if not path.is_absolute():
+            path = repo_root / path
+        path = path.resolve()
+        if path.is_file():
+            candidates = [path]
+        else:
+            candidates = sorted(path.rglob("*.py"))
+        for candidate in candidates:
+            if candidate.name == "__init__.py":
+                continue
+            if "__pycache__" in candidate.parts:
+                continue
+            if candidate in seen:
+                continue
+            seen.add(candidate)
+            yield candidate
+
+
+def _matches_filters(path, repo_root, only, exclude, exclude_dirs):
+    rel = _display_path(path, repo_root)
+    rel_posix = rel.replace(os.sep, "/")
+    if only and not any(token in rel_posix for token in only):
+        return False
+    if exclude and any(token in rel_posix for token in exclude):
+        return False
+    parts = set(Path(rel).parts)
+    if exclude_dirs and any(dirname in parts for dirname in exclude_dirs):
+        return False
+    return True
+
+
+def _safe_log_name(script, repo_root):
+    rel = _display_path(script, repo_root)
+    name = rel.replace("\\", "__").replace("/", "__").replace(":", "")
+    return name
+
+
+def _patch_gui_entry_points():
+    try:
+        from xrt.backends.raycing import beamline
+    except Exception:
+        return
+
+    def _skip_gui(self, *args, **kwargs):
+        print("xrt example runner: skipped GUI call on {0}".format(
+            getattr(self, "name", self.__class__.__name__)))
+        return None
+
+    beamline.BeamLine.glow = _skip_gui
+    beamline.BeamLine.explore = _skip_gui
+
+
+def _patch_matplotlib(keep_artifacts):
+    import matplotlib
+    matplotlib.use("Agg", force=True)
+    import matplotlib.pyplot as plt
+
+    def _show(*args, **kwargs):
+        plt.close("all")
+
+    plt.show = _show
+
+    if not keep_artifacts:
+        from matplotlib.figure import Figure
+
+        def _skip_savefig(self, *args, **kwargs):
+            if args:
+                print("xrt example runner: skipped savefig {0}".format(
+                    args[0]))
+            return None
+
+        Figure.savefig = _skip_savefig
+
+
+def _set_beamline_nrays(beam_line, nrays):
+    if beam_line is None:
+        return
+    if hasattr(beam_line, "nrays"):
+        beam_line.nrays = nrays
+    for source in getattr(beam_line, "sources", []):
+        if hasattr(source, "nrays"):
+            source.nrays = nrays
+
+
+def _suppress_plot_artifacts(plots):
+    for plot in _as_list(plots):
+        if hasattr(plot, "saveName"):
+            plot.saveName = None
+        if hasattr(plot, "persistentName"):
+            plot.persistentName = None
+
+
+def _limited_generator_factory(generator, max_steps):
+    def _limited_generator(*args, **kwargs):
+        generated = generator(*args, **kwargs)
+        if generated is None:
+            return
+        for step, value in enumerate(generated):
+            if step >= max_steps:
+                break
+            yield value
+
+    _limited_generator.__name__ = getattr(
+        generator, "__name__", "_limited_generator")
+    return _limited_generator
+
+
+def _patch_runner(nrays, repeats, generator_steps, keep_artifacts):
+    from xrt.backends import raycing
+    import xrt.runner as xrtr
+
+    raycing.nrays = nrays
+    original_run_ray_tracing = xrtr.run_ray_tracing
+    signature = inspect.signature(original_run_ray_tracing)
+
+    def _run_ray_tracing_smoke(*args, **kwargs):
+        caller_frame = inspect.currentframe().f_back
+        bound = signature.bind_partial(*args, **kwargs)
+        bound.apply_defaults()
+
+        plots = bound.arguments.get("plots")
+        beam_line = bound.arguments.get("beamLine")
+        _set_beamline_nrays(beam_line, nrays)
+        if not keep_artifacts:
+            _suppress_plot_artifacts(plots)
+
+        bound.arguments["repeats"] = repeats
+        bound.arguments["updateEvery"] = 1
+        bound.arguments["threads"] = 1
+        bound.arguments["processes"] = 1
+        bound.arguments["pickleEvery"] = None
+        bound.arguments["globalNorm"] = 0
+        bound.arguments["afterScript"] = None
+
+        generator = bound.arguments.get("generator")
+        if generator is not None:
+            generator_args = bound.arguments.get("generatorArgs") or []
+            generator_kwargs = bound.arguments.get("generatorKWargs")
+            if generator_kwargs == "auto":
+                generator_name = getattr(generator, "__name__", "")
+                if (generator_name in caller_frame.f_locals) or generator_args:
+                    generator_kwargs = {}
+                else:
+                    generator_kwargs = {"plots": plots, "beamLine": beam_line}
+                bound.arguments["generatorKWargs"] = generator_kwargs
+            if generator_steps is not None:
+                bound.arguments["generator"] = _limited_generator_factory(
+                    generator, generator_steps)
+
+        return original_run_ray_tracing(**bound.arguments)
+
+    xrtr.run_ray_tracing = _run_ray_tracing_smoke
+
+
+def _execute_script(script, repo_root, force_no_3d, force_rays):
+    script = Path(script).resolve()
+    os.chdir(str(script.parent))
+    for path in (str(repo_root), str(script.parent)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+    old_argv = sys.argv[:]
+    sys.argv = [str(script)]
+    try:
+        source = script.read_text(encoding="utf-8-sig")
+        tree = ast.parse(source, filename=str(script))
+        tree = _ExampleSourceTransformer(
+            force_no_3d=force_no_3d, force_rays=force_rays).visit(tree)
+        globals_dict = {
+            "__name__": "__main__",
+            "__file__": str(script),
+            "__package__": None,
+            "__cached__": None,
+        }
+        exec(compile(tree, str(script), "exec"), globals_dict)
+    finally:
+        sys.argv = old_argv
+
+
+def run_one(args):
+    repo_root = Path(args.repo_root).resolve()
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    os.environ["XRT_EXAMPLE_NRAYS"] = str(args.nrays)
+    os.environ["XRT_EXAMPLE_REPEATS"] = str(args.repeats)
+
+    _patch_matplotlib(args.keep_artifacts)
+    _patch_gui_entry_points()
+    _patch_runner(
+        args.nrays, args.repeats,
+        None if args.generator_steps < 1 else args.generator_steps,
+        args.keep_artifacts)
+    _execute_script(
+        args.run_one, repo_root, args.force_no_3d, args.force_rays)
+    return 0
+
+
+def run_suite(args):
+    repo_root = Path(args.repo_root).resolve()
+    paths = args.paths or [str(DEFAULT_EXAMPLES)]
+    exclude_dirs = list(args.exclude_dir)
+    if args.skip_waves and "11_Waves" not in exclude_dirs:
+        exclude_dirs.append("11_Waves")
+
+    scripts = [
+        script for script in _iter_example_scripts(paths, repo_root)
+        if _matches_filters(
+            script, repo_root, args.only, args.exclude, exclude_dirs)]
+
+    if args.list:
+        for script in scripts:
+            print(_display_path(script, repo_root))
+        print("{0} script(s)".format(len(scripts)))
+        return 0
+
+    log_dir = Path(args.log_dir).resolve()
+    log_dir.mkdir(parents=True, exist_ok=True)
+    print("Running {0} script(s); logs: {1}".format(len(scripts), log_dir))
+
+    failures = []
+    for index, script in enumerate(scripts, 1):
+        rel = _display_path(script, repo_root)
+        log_base = log_dir / _safe_log_name(script, repo_root)
+        stdout_path = log_base.with_suffix(".out.log")
+        stderr_path = log_base.with_suffix(".err.log")
+        cmd = [
+            args.python,
+            str(Path(__file__).resolve()),
+            "--run-one", str(script),
+            "--repo-root", str(repo_root),
+            "--nrays", str(args.nrays),
+            "--repeats", str(args.repeats),
+            "--generator-steps", str(args.generator_steps),
+        ]
+        if args.keep_artifacts:
+            cmd.append("--keep-artifacts")
+        if args.no_force_no_3d:
+            cmd.append("--no-force-no-3d")
+        if args.force_rays:
+            cmd.append("--force-rays")
+
+        env = os.environ.copy()
+        env.setdefault("MPLBACKEND", "Agg")
+        env.setdefault("QT_QPA_PLATFORM", "offscreen")
+        env["PYTHONPATH"] = os.pathsep.join(
+            [str(repo_root), env.get("PYTHONPATH", "")])
+
+        print("[{0}/{1}] {2}".format(index, len(scripts), rel))
+        start = time.time()
+        with stdout_path.open("w", encoding="utf-8") as stdout, \
+                stderr_path.open("w", encoding="utf-8") as stderr:
+            proc = subprocess.Popen(
+                cmd, cwd=str(repo_root), env=env, stdout=stdout,
+                stderr=stderr, text=True)
+            try:
+                proc.wait(timeout=args.timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+                stderr.write("\nTIMEOUT after {0} s\n".format(args.timeout))
+                rc = 124
+            else:
+                rc = proc.returncode
+        elapsed = time.time() - start
+        if rc:
+            failures.append((rel, rc, stdout_path, stderr_path))
+            print("  failed: exit={0}, {1:.1f} s".format(rc, elapsed))
+            if args.fail_fast:
+                break
+        else:
+            print("  ok: {0:.1f} s".format(elapsed))
+
+    if failures:
+        print("\nFailures:")
+        for rel, rc, stdout_path, stderr_path in failures:
+            print("  {0}: exit={1}".format(rel, rc))
+            print("    stdout: {0}".format(stdout_path))
+            print("    stderr: {0}".format(stderr_path))
+        return 1
+
+    print("\nAll selected examples passed.")
+    return 0
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        description="Run raycing examples with reduced ray-tracing settings.")
+    parser.add_argument(
+        "paths", nargs="*",
+        help="Example files or directories. Defaults to examples/withRaycing.")
+    parser.add_argument(
+        "--repo-root", default=str(ROOT),
+        help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--run-one", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--python", default=sys.executable,
+        help="Python executable for child processes. Default: current Python.")
+    parser.add_argument(
+        "--nrays", type=int, default=10000,
+        help="Number of rays assigned to raycing sources. Default: 10000.")
+    parser.add_argument(
+        "--repeats", type=int, default=1,
+        help="run_ray_tracing repeats value. Default: 1.")
+    parser.add_argument(
+        "--generator-steps", type=int, default=1,
+        help="Maximum generator scan steps. Use 0 for unlimited. Default: 1.")
+    parser.add_argument(
+        "--timeout", type=float, default=300.0,
+        help="Timeout per script in seconds. Default: 300.")
+    parser.add_argument(
+        "--log-dir",
+        default=str(Path(tempfile.gettempdir()) / "xrt-example-logs"),
+        help="Directory for child stdout/stderr logs.")
+    parser.add_argument(
+        "--only", action="append", default=[],
+        help="Run scripts whose repository-relative path contains this text.")
+    parser.add_argument(
+        "--exclude", action="append", default=[],
+        help="Skip scripts whose repository-relative path contains this text.")
+    parser.add_argument(
+        "--exclude-dir", action="append", default=[],
+        help="Skip scripts below a directory with this exact name.")
+    parser.add_argument(
+        "--skip-waves", action="store_true",
+        help="Shortcut for --exclude-dir 11_Waves.")
+    parser.add_argument(
+        "--force-rays", action="store_true",
+        help="Set module-level what = 'rays' in memory before execution.")
+    parser.add_argument(
+        "--no-force-no-3d", dest="no_force_no_3d", action="store_true",
+        help="Do not force module-level showIn3D = False.")
+    parser.add_argument(
+        "--keep-artifacts", action="store_true",
+        help="Allow examples to save figures/persistent files.")
+    parser.add_argument(
+        "--fail-fast", action="store_true",
+        help="Stop after the first failure.")
+    parser.add_argument(
+        "--list", action="store_true",
+        help="List selected scripts without running them.")
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.run_one:
+        args.force_no_3d = not args.no_force_no_3d
+        return run_one(args)
+    return run_suite(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xrt/backends/raycing/__init__.py
+++ b/xrt/backends/raycing/__init__.py
@@ -225,6 +225,7 @@ from ._flow_utils import (
     auto_units_angle, auto_units_angle_with_energy, append_to_flow,
     append_to_flow_decorator, set_name, vec_to_quat, multiply_quats,
     quat_vec_rotate, get_init_val, get_params, parametrize,
+    normalize_ref, ref_kind_for_arg,
     create_paramdict_oe, create_paramdict_mat, get_obj_str, get_init_kwargs,
     is_valid_uuid, run_process_from_file, build_hist, parse_energy_string,
     is_auto_align_value, get_auto_align_energy, format_energy_input,

--- a/xrt/backends/raycing/_flow.py
+++ b/xrt/backends/raycing/_flow.py
@@ -255,8 +255,9 @@ class MessageHandler:
                 oeObj = oeLine[0]
                 for prop in ["_material", "_material2"]:
                     try:
-                        matProp = getattr(oeObj, prop, None)
-                        if matProp == objuuid:
+                        if self.bl._ref_contains(
+                                getattr(oeObj, prop, None),
+                                'material', objuuid):
                             self.startEl = oeid
                             break
                     except AttributeError:
@@ -265,6 +266,7 @@ class MessageHandler:
             if self.autoUpdate and self.startEl is not None:
                 self.needUpdate = True
         elif object_type == 'fe':
+            self.startEl = None
             feObj = self.bl.fesDict.get(objuuid)
             if feObj is not None:
                 for key, value in kwargs.items():
@@ -281,8 +283,9 @@ class MessageHandler:
                 oeObj = oeLine[0]
                 for prop in ["_figureError"]:
                     try:
-                        feProp = getattr(oeObj, prop, None)
-                        if feProp == objuuid:
+                        if self.bl._ref_contains(
+                                getattr(oeObj, prop, None),
+                                'figureError', objuuid):
                             self.startEl = oeid
                             break
                     except AttributeError:
@@ -315,8 +318,9 @@ class MessageHandler:
                 oeObj = oeLine[0]
                 for prop in ["_material", "_material2"]:
                     try:
-                        matProp = getattr(oeObj, prop, None)
-                        if matProp == objuuid:
+                        if self.bl._ref_contains(
+                                getattr(oeObj, prop, None),
+                                'material', objuuid):
                             self.startEl = oeid
                             break
                     except AttributeError:
@@ -331,8 +335,9 @@ class MessageHandler:
                 oeObj = oeLine[0]
                 for prop in ["_figureError"]:
                     try:
-                        feProp = getattr(oeObj, prop, None)
-                        if feProp == objuuid:
+                        if self.bl._ref_contains(
+                                getattr(oeObj, prop, None),
+                                'figureError', objuuid):
                             self.startEl = oeid
                             break
                     except AttributeError:

--- a/xrt/backends/raycing/_flow_utils.py
+++ b/xrt/backends/raycing/_flow_utils.py
@@ -530,10 +530,13 @@ def normalize_ref(value, bl=None, refKind='material', target='uuid'):
             return value
         if textValue is not None:
             uuidValue = uuid_from_name(textValue)
-            if uuidValue is None:
+            if uuidValue is None and is_valid_uuid(textValue):
                 uuidValue = textValue
+            if uuidValue is None:
+                return value
             obj = object_from_uuid(uuidValue)
-            return obj if obj is not None else value
+            return obj if obj is not None else (
+                None if bl is not None else value)
         return value
 
 

--- a/xrt/backends/raycing/_flow_utils.py
+++ b/xrt/backends/raycing/_flow_utils.py
@@ -407,14 +407,141 @@ def parametrize(value):
     return value
 
 
-def _material_ref_to_uuid(material, bl=None):
-    if hasattr(material, 'uuid'):
-        return material.uuid
-    if bl is not None and isinstance(material, str):
-        matId = bl.matnamesToUUIDs.get(material)
-        if matId is not None:
-            return matId
-    return material
+REFERENCE_KINDS = {
+    'material': {
+        'dict': 'materialsDict',
+        'names': 'matnamesToUUIDs',
+        'fields': {
+            'material', 'material2', 'tlayer', 'blayer', 'coating',
+            'substrate', 'materialsindex'},
+        'prefixes': ('material', 'tlay', 'blay', 'coat', 'substrate'),
+    },
+    'figureError': {
+        'dict': 'fesDict',
+        'names': 'fenamesToUUIDs',
+        'fields': {'figureerror', 'basefe'},
+        'prefixes': ('figureerr', 'basefe'),
+    },
+    'oe': {
+        'dict': 'oesDict',
+        'names': 'oenamesToUUIDs',
+        'objectIndex': 0,
+        'fields': set(),
+        'prefixes': tuple(),
+    },
+}
+
+def ref_kind_for_arg(argName):
+    argNameL = str(argName).lower()
+    for refKind, spec in REFERENCE_KINDS.items():
+        if argNameL in spec.get('fields', set()):
+            return refKind
+        if any(argNameL.startswith(prefix) for
+               prefix in spec.get('prefixes', tuple())):
+            return refKind
+    return None
+
+
+def normalize_ref(value, bl=None, refKind='material', target='uuid'):
+    """
+    Normalize references between GUI names, UUIDs and runtime objects.
+
+    ``value`` can be a scalar, list, tuple or dict. Containers are traversed
+    recursively; dict keys are preserved and only dict values are normalized.
+
+    ``refKind`` selects the reference registry entry, for example
+    ``'material'``, ``'figureError'`` or ``'oe'``. ``target`` can be:
+
+    * ``'display'`` or ``'name'``: object/UUID -> human-readable name.
+    * ``'uuid'``: object/name -> UUID.
+    * ``'object'``: name/UUID -> runtime object.
+
+    Unknown values are returned unchanged. This lets scripts keep literal
+    objects or already-normalized identifiers without special casing.
+    """
+    if isinstance(value, dict):
+        return {
+            key: normalize_ref(item, bl, refKind, target)
+            for key, item in value.items()}
+    if isinstance(value, list):
+        return [normalize_ref(item, bl, refKind, target) for item in value]
+    if isinstance(value, tuple):
+        return tuple(normalize_ref(item, bl, refKind, target)
+                     for item in value)
+
+    if refKind not in REFERENCE_KINDS:
+        raise KeyError('Unknown reference kind {0!r}'.format(refKind))
+
+    target = str(target).lower()
+    if target == 'name':
+        target = 'display'
+    if target not in {'display', 'uuid', 'object'}:
+        raise ValueError('Unknown reference target {0!r}'.format(target))
+
+    spec = REFERENCE_KINDS[refKind]
+    if value is None:
+        return None
+
+    def string_value(ref):
+        if isinstance(ref, bytes):
+            return ref.decode()
+        return ref if isinstance(ref, str) else None
+
+    def object_from_uuid(ref):
+        if bl is None:
+            return None
+        refDict = getattr(bl, spec['dict'], {})
+        obj = refDict.get(ref)
+        objIndex = spec.get('objectIndex')
+        if obj is not None and objIndex is not None:
+            try:
+                obj = obj[objIndex]
+            except (IndexError, TypeError):
+                pass
+        return obj
+
+    def uuid_from_name(ref):
+        if bl is None:
+            return None
+        namesDict = getattr(bl, spec['names'], {})
+        return namesDict.get(ref)
+
+    textValue = string_value(value)
+
+    if target == 'display':
+        if hasattr(value, 'name'):
+            return value.name
+        if textValue is not None:
+            obj = object_from_uuid(textValue)
+            if obj is not None and hasattr(obj, 'name'):
+                return obj.name
+        return value
+
+    if target == 'uuid':
+        if hasattr(value, 'uuid'):
+            return value.uuid
+        if textValue is not None:
+            uuidValue = uuid_from_name(textValue)
+            return uuidValue if uuidValue is not None else value
+        return value
+
+    if target == 'object':
+        if hasattr(value, 'uuid'):
+            return value
+        if textValue is not None:
+            uuidValue = uuid_from_name(textValue)
+            if uuidValue is None:
+                uuidValue = textValue
+            obj = object_from_uuid(uuidValue)
+            return obj if obj is not None else value
+        return value
+
+
+def _parametrize_reference(value, bl=None, refKind='material'):
+    if not (isinstance(value, basestring) and is_valid_uuid(value)):
+        value = parametrize(value)
+    return normalize_ref(value, bl, refKind, target='uuid')
+
 
 
 def create_paramdict_oe(paramDictStr, defArgs, beamLine=None):
@@ -438,24 +565,15 @@ def create_paramdict_oe(paramDictStr, defArgs, beamLine=None):
                     [get_init_val(c.strip())
                      for c in str.split(
                      paravalue, ',')]
-            elif paraname.startswith('material'):
-                if str(paravalue) in beamLine.matnamesToUUIDs:
-                    paravalue = beamLine.matnamesToUUIDs[paravalue]
-                elif is_valid_uuid(paravalue):
-                    pass
-                else:  # tuple or list
-                    paravalue = paravalue.strip('[]() ')
-                    paravalue =\
-                        [get_init_val(c.strip())
-                         for c in str.split(
-                         paravalue, ',')]
-            elif paraname.startswith('figure'):
-                if str(paravalue) in beamLine.fenamesToUUIDs:
-                    paravalue = beamLine.fenamesToUUIDs[paravalue]
             elif paraname == 'bl':
                 paravalue = beamLine
             else:
-                paravalue = parametrize(paravalue)
+                refKind = ref_kind_for_arg(paraname)
+                if refKind is not None:
+                    paravalue = _parametrize_reference(
+                        paravalue, beamLine, refKind)
+                else:
+                    paravalue = parametrize(paravalue)
             kwargs[paraname] = paravalue
 
     if {'opening', 'x', 'y'} & paramDictStr.keys():
@@ -478,22 +596,9 @@ def create_paramdict_mat(paramDictStr, defArgs, bl=None):
     for paraname, paravalue in paramDictStr.items():
         if (paraname in defArgs and paravalue != str(defArgs[paraname])) or\
                 paravalue == 'bl':
-            paranameL = paraname.lower()
-            if paranameL == 'materialsindex':
-                paravalue = parametrize(paravalue)
-                if isinstance(paravalue, dict):
-                    paravalue = {
-                        key: _material_ref_to_uuid(value, bl)
-                        for key, value in paravalue.items()}
-            elif paranameL in ['tlayer', 'blayer', 'coating',
-                               'substrate']:
-                if str(paravalue) in bl.matnamesToUUIDs:
-                    paravalue = bl.matnamesToUUIDs[paravalue]
-#                if is_valid_uuid(paravalue):
-#                    paravalue = bl.materialsDict[paravalue]
-#                elif paravalue in bl.matnamesToUUIDs:
-#                    paravalue = bl.materialsDict.get(
-#                            bl.matnamesToUUIDs[paravalue])
+            refKind = ref_kind_for_arg(paraname)
+            if refKind is not None:
+                paravalue = _parametrize_reference(paravalue, bl, refKind)
             else:
                 paravalue = parametrize(paravalue)
             kwargs[paraname] = paravalue
@@ -506,9 +611,9 @@ def create_paramdict_fe(paramDictStr, defArgs, bl=None):
     for paraname, paravalue in paramDictStr.items():
         if (paraname in defArgs and paravalue != str(defArgs[paraname])) or\
                 paravalue == 'bl':
-            if paraname.lower() in ['basefe']:
-                if str(paravalue) in bl.fenamesToUUIDs:
-                    paravalue = bl.fenamesToUUIDs[paravalue]
+            refKind = ref_kind_for_arg(paraname)
+            if refKind is not None:
+                paravalue = _parametrize_reference(paravalue, bl, refKind)
             else:
                 paravalue = parametrize(paravalue)
             kwargs[paraname] = paravalue
@@ -526,6 +631,17 @@ def get_init_kwargs(oeObj, compact=True, needRevG=False, blname=None,
         globRev = {str(v): k for k, v in globals().items()}
 
     defArgs = dict(get_params(get_obj_str(oeObj)))
+    bl = getattr(oeObj, 'bl', None)
+
+    def get_global_name(value):
+        if isinstance(value, dict):
+            return {key: get_global_name(item)
+                    for key, item in value.items()}
+        if isinstance(value, list):
+            return [get_global_name(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(get_global_name(item) for item in value)
+        return globRev.get(str(value), value)
 
     initArgs = {}
     for arg, val in defArgs.items():
@@ -544,40 +660,13 @@ def get_init_kwargs(oeObj, compact=True, needRevG=False, blname=None,
                 if arg == 'elements':
                     realval = [x.name for x in realval]
 
-                if str(arg).lower().startswith(
-                        ('material', 'coating', 'substrate', 'tlay', 'blay')):
-                    if arg == 'materialsIndex' and isinstance(realval, dict):
-                        realval = {
-                            key: _material_ref_to_uuid(value)
-                            for key, value in realval.items()}
-                    elif is_sequence(realval):
-                        outv = []
-                        for trval in realval:
-                            if hasattr(trval, 'uuid'):
-                                trval = trval.uuid
-                            elif needRevG:
-                                trval = globRev[str(trval)]
-                            else:  # already uuid or something is wrong
-                                pass
-                            outv.append(trval)
-                        realval = outv
-                    else:
-                        if hasattr(realval, 'uuid'):
-                            realval = realval.uuid
-                        elif needRevG:
-                            realval = globRev[str(realval)]
-                        else:  # already uuid or something is wrong
-                            pass
+                refKind = ref_kind_for_arg(arg)
+                if refKind is not None:
+                    realval = normalize_ref(
+                        realval, bl, refKind, target='uuid')
+                    if needRevG:
+                        realval = get_global_name(realval)
 
-                if str(arg).lower().startswith(
-                        ('figureerr', 'basefe')):
-                    if hasattr(realval, 'uuid'):
-                        realval = realval.uuid
-                    elif needRevG:
-                        realval = globRev[str(realval)]
-                    else:
-                        pass
-#                        print("Cannot resolve material")
                 realval = normalize_string_input(realval)
                 val = normalize_string_input(val)
                 if realval != val:

--- a/xrt/backends/raycing/apertures.py
+++ b/xrt/backends/raycing/apertures.py
@@ -280,15 +280,19 @@ class RectangularAperture(object):
         self._set_orientation()
 
     def _sync_blades_from_legacy(self):
-        self._blades = {
-            key: value for key, value in zip(self._kind, self._opening)
-            if value is not None}
+        self._blades = self._legacy_blades_from_opening()
         if self._blades:
             self.set_optical_limits()
 
+    def _legacy_blades_from_opening(self):
+        return {
+            key: value for key, value in zip(self._kind, self._opening)
+            if value is not None}
+
     def set_optical_limits(self):
         """For plotting footprint images with the envelope aperture."""
-        for akind, d in self.blades.items():
+        self._blades = self._legacy_blades_from_opening()
+        for akind, d in self._blades.items():
             td = float(d)  # otherwise is of type 'numpy.float64' and
             # raycing.is_sequence(d) returns True which is unexpected.
             if akind.startswith('l'):

--- a/xrt/backends/raycing/beamline.py
+++ b/xrt/backends/raycing/beamline.py
@@ -24,7 +24,7 @@ from ._flow_utils import (
     get_params, create_paramdict_oe, is_valid_uuid, parametrize,
     create_paramdict_mat, get_init_val, get_init_kwargs, get_obj_str,
     create_paramdict_fe, is_auto_align_value, get_auto_align_energy,
-    warn_deprecated_glow_v2, normalize_string_input)
+    warn_deprecated_glow_v2, normalize_string_input, normalize_ref)
 from ._rotate import rotate_z, rotate_beam
 from ._named_arrays import Center
 
@@ -630,6 +630,45 @@ class BeamLine(object):
             if oeid not in seen:
                 yield oeid, oeLine
 
+    def _normalized_ref_values(self, value, refKind):
+        value = normalize_ref(value, self, refKind, target='uuid')
+        if isinstance(value, dict):
+            values = value.values()
+        elif is_sequence(value):
+            values = value
+        else:
+            values = (value,)
+        return [v for v in values if v is not None and str(v) != 'None']
+
+    def _clear_ref_value(self, value, refKind, refId):
+        normValue = normalize_ref(value, self, refKind, target='uuid')
+        if isinstance(normValue, dict):
+            newValue = value.copy() if hasattr(value, 'copy') else dict(value)
+            changed = False
+            for key, item in normValue.items():
+                if item == refId:
+                    newValue[key] = None
+                    changed = True
+            return newValue if changed else value
+
+        if is_sequence(normValue):
+            changed = False
+            newItems = []
+            for oldItem, normItem in zip(value, normValue):
+                if normItem == refId:
+                    newItems.append(None)
+                    changed = True
+                else:
+                    newItems.append(oldItem)
+            if not changed:
+                return value
+            return tuple(newItems) if isinstance(value, tuple) else newItems
+
+        return None if normValue == refId else value
+
+    def _ref_contains(self, value, refKind, refId):
+        return refId in self._normalized_ref_values(value, refKind)
+
     def sort_materials(self, matDict=None, fromJSON=False):
         visited = set()
         visiting = set()
@@ -642,23 +681,14 @@ class BeamLine(object):
             if not isinstance(materialsIndex, dict):
                 return []
 
-            deps = []
-            for material in materialsIndex.values():
-                if isinstance(material, str):
-                    deps.append(material)
-                elif material is not None and hasattr(material, 'uuid'):
-                    deps.append(getattr(material, 'uuid'))
-            return deps
+            return self._normalized_ref_values(materialsIndex, 'material')
 
         def get_dep_obj(matObj):
             deps = []
             for attr in matDeps:
                 if hasattr(matObj, attr):
-                    v = getattr(matObj, attr)
-                    if is_valid_uuid(v):
-                        deps.append(v)
-                    elif v is not None and hasattr(v, 'uuid'):
-                        deps.append(getattr(v, 'uuid'))
+                    deps.extend(self._normalized_ref_values(
+                        getattr(matObj, attr), 'material'))
             if hasattr(matObj, 'materialsIndex'):
                 deps.extend(get_index_deps(matObj.materialsIndex))
             return deps
@@ -670,7 +700,8 @@ class BeamLine(object):
                 for attr in matDeps:
                     v = props.get(attr)
                     if v is not None:
-                        deps.append(v)
+                        deps.extend(self._normalized_ref_values(
+                            v, 'material'))
                 materialsIndex = props.get('materialsIndex')
                 if materialsIndex is not None:
                     deps.extend(get_index_deps(materialsIndex))
@@ -710,11 +741,8 @@ class BeamLine(object):
             deps = []
             for attr in feDeps:
                 if hasattr(feObj, attr):
-                    v = getattr(feObj, attr)
-                    if is_valid_uuid(v):
-                        deps.append(v)
-                    elif v is not None and hasattr(v, 'uuid'):
-                        deps.append(getattr(v, 'uuid'))
+                    deps.extend(self._normalized_ref_values(
+                        getattr(feObj, attr), 'figureError'))
             return deps
 
         def get_dep_json(pDict):
@@ -724,7 +752,8 @@ class BeamLine(object):
                 for attr in feDeps:
                     v = props.get(attr)
                     if v is not None:
-                        deps.append(v)
+                        deps.extend(self._normalized_ref_values(
+                            v, 'figureError'))
             return deps
 
         def dfs(mId, mProps):
@@ -736,7 +765,7 @@ class BeamLine(object):
             visiting.add(mId)
             if mProps is not None:
                 for dep in get_dependencies(mProps):
-                    dfs(dep, None)
+                    dfs(dep, feDict.get(dep))
             visiting.remove(mId)
             visited.add(mId)
             sortedFEList.append(mId)
@@ -756,30 +785,57 @@ class BeamLine(object):
             if mat is None:
                 return None
 
+            originalMat = mat
+            mat = normalize_ref(mat, self, 'material', target='object')
+            if mat is None:
+                return None
+            if not hasattr(mat, 'uuid'):
+                return normalize_ref(
+                    originalMat, self, 'material', target='uuid')
+
             if hasattr(mat, 'materialsIndex'):
                 for subMat in mat.materialsIndex.values():
-                    if subMat is not None and hasattr(subMat, 'uuid') and\
-                            subMat.uuid not in materialsDict:
-                        materialsDict[subMat.uuid] = subMat
-                        matNamesDict[subMat.name] = subMat.uuid
-                        materialsDict.move_to_end(subMat.uuid, last=False)
+                    subMatId = register_material(subMat)
+                    if subMatId in materialsDict:
+                        materialsDict.move_to_end(subMatId, last=False)
 
             for subAttr in ['tLayer', 'bLayer', 'coating', 'substrate']:
                 if hasattr(mat, subAttr):
                     subMat = getattr(mat, subAttr)
-
-                    if subMat is not None and hasattr(subMat, 'uuid'):
-                        if subMat.uuid not in materialsDict:
-                            materialsDict[subMat.uuid] = subMat
-                            matNamesDict[subMat.name] = subMat.uuid
-                            materialsDict.move_to_end(subMat.uuid, last=False)
-                        setattr(mat, subAttr, subMat.uuid)
+                    subMatId = register_material(subMat)
+                    if subMatId is not None:
+                        if subMatId in materialsDict:
+                            materialsDict.move_to_end(subMatId, last=False)
+                        setattr(mat, subAttr, subMatId)
 
             if mat.uuid not in materialsDict:
                 materialsDict[mat.uuid] = mat
                 matNamesDict[mat.name] = mat.uuid
 
             return mat.uuid
+
+        def register_fe(fe):
+            if fe is None:
+                return None
+
+            originalFE = fe
+            fe = normalize_ref(fe, self, 'figureError', target='object')
+            if fe is None:
+                return None
+            if not hasattr(fe, 'uuid'):
+                return normalize_ref(
+                    originalFE, self, 'figureError', target='uuid')
+
+            if hasattr(fe, 'baseFE'):
+                subFEId = register_fe(getattr(fe, 'baseFE', None))
+                if subFEId is not None:
+                    setattr(fe, 'baseFE', subFEId)
+
+            if fe.uuid not in feDict:
+                feDict[fe.uuid] = fe
+                feNamesDict[fe.name] = fe.uuid
+
+            return fe.uuid
 
         materialsDict = OrderedDict()
         matNamesDict = OrderedDict()
@@ -821,23 +877,8 @@ class BeamLine(object):
 
             for attr in ['figureError']:
                 if hasattr(oe, attr):
-                    newFE = getattr(oe, attr, None)
-                    if hasattr(newFE, 'uuid') and newFE.uuid not in feDict:
-                        feDict[newFE.uuid] = newFE
-                        feNamesDict[newFE.name] = newFE.uuid
-                        setattr(oe, 'figureError', newFE.uuid)
-
-                    for subAttr in ['baseFE']:
-                        if hasattr(newFE, subAttr):
-                            subFE = getattr(newFE, subAttr, None)
-                            if hasattr(subFE, 'uuid') and\
-                                    subFE.uuid not in feDict:
-                                feDict[subFE.uuid] = subFE
-                                feNamesDict[subFE.name] = subFE.uuid
-                                feDict.move_to_end(
-                                        subFE.uuid,
-                                        last=False)
-                                setattr(subFE, 'baseFE', subFE.uuid)
+                    newFE = register_fe(getattr(oe, attr, None))
+                    setattr(oe, attr, newFE)
 
         self.materialsDict.update(materialsDict)
         # self.matnamesToUUIDs.update(matNamesDict)
@@ -1252,45 +1293,66 @@ class BeamLine(object):
             del self.oesDict[elid]
 
     def delete_mat_by_id(self, matid):
-        for matname, tmpid in self.matnamesToUUIDs.items():
-            if tmpid == matid:
-                del self.matnamesToUUIDs[matname]
-                break
+        if matid not in self.materialsDict:
+            for matname, tmpid in list(self.matnamesToUUIDs.items()):
+                if tmpid == matid:
+                    del self.matnamesToUUIDs[matname]
+                    break
+            return
 
         for elid, elLine in self.oesDict.items():
             elObj = elLine[0]
             for prop in ['material', 'material2']:
-                if hasattr(elObj, prop) and \
-                        getattr(elObj, prop) == self.materialsDict[matid]:
-                    setattr(elObj, prop, None)
+                if hasattr(elObj, prop):
+                    newValue = self._clear_ref_value(
+                        getattr(elObj, prop), 'material', matid)
+                    setattr(elObj, prop, newValue)
 
-        for tmpid, matobj in self.materialsDict.items():
+        for tmpid, matobj in list(self.materialsDict.items()):
             for prop in ['tLayer', 'bLayer', 'coating', 'substrate']:
-                if hasattr(matobj, prop) and \
-                        getattr(matobj, prop) == self.materialsDict[matid]:
-                    setattr(matobj, prop, None)
+                if hasattr(matobj, prop):
+                    newValue = self._clear_ref_value(
+                        getattr(matobj, prop), 'material', matid)
+                    setattr(matobj, prop, newValue)
+            if hasattr(matobj, 'materialsIndex'):
+                matobj.materialsIndex = self._clear_ref_value(
+                    matobj.materialsIndex, 'material', matid)
+
+        for matname, tmpid in list(self.matnamesToUUIDs.items()):
+            if tmpid == matid:
+                del self.matnamesToUUIDs[matname]
+                break
 
         if matid in self.materialsDict:
             del self.materialsDict[matid]
 
     def delete_fe_by_id(self, feid):
-        for fename, tmpid in self.fenamesToUUIDs.items():
-            if tmpid == feid:
-                del self.fenamesToUUIDs[fename]
-                break
+        if feid not in self.fesDict:
+            for fename, tmpid in list(self.fenamesToUUIDs.items()):
+                if tmpid == feid:
+                    del self.fenamesToUUIDs[fename]
+                    break
+            return
 
         for elid, elLine in self.oesDict.items():
             elObj = elLine[0]
             for prop in ['figureError']:
-                if hasattr(elObj, prop) and \
-                        getattr(elObj, prop) == self.fesDict[feid]:
-                    setattr(elObj, prop, None)
+                if hasattr(elObj, prop):
+                    newValue = self._clear_ref_value(
+                        getattr(elObj, prop), 'figureError', feid)
+                    setattr(elObj, prop, newValue)
 
-        for tmpid, feobj in self.fesDict.items():
+        for tmpid, feobj in list(self.fesDict.items()):
             for prop in ['baseFE']:
-                if hasattr(feobj, prop) and \
-                        getattr(feobj, prop) == self.fesDict[feid]:
-                    setattr(feobj, prop, None)
+                if hasattr(feobj, prop):
+                    newValue = self._clear_ref_value(
+                        getattr(feobj, prop), 'figureError', feid)
+                    setattr(feobj, prop, newValue)
+
+        for fename, tmpid in list(self.fenamesToUUIDs.items()):
+            if tmpid == feid:
+                del self.fenamesToUUIDs[fename]
+                break
 
         if feid in self.fesDict:
             del self.fesDict[feid]

--- a/xrt/backends/raycing/figure_error.py
+++ b/xrt/backends/raycing/figure_error.py
@@ -89,11 +89,8 @@ class FigureErrorBase():
 
     @property
     def baseFE(self):
-        if raycing.is_valid_uuid(self._baseFE) and self.bl is not None:
-            fe = self.bl.fesDict.get(self._baseFE)
-        else:
-            fe = self._baseFE
-        return fe
+        return raycing.normalize_ref(
+            self._baseFE, self.bl, 'figureError', target='object')
 
     @baseFE.setter
     def baseFE(self, baseFE):

--- a/xrt/backends/raycing/materials/multilayer.py
+++ b/xrt/backends/raycing/materials/multilayer.py
@@ -163,11 +163,8 @@ class Multilayer(object):
 
     @property
     def tLayer(self):
-        if raycing.is_valid_uuid(self._tLayer) and self.bl is not None:
-            mat = self.bl.materialsDict.get(self._tLayer)
-        else:
-            mat = self._tLayer
-        return mat
+        return raycing.normalize_ref(
+            self._tLayer, self.bl, 'material', target='object')
 
     @tLayer.setter
     def tLayer(self, tLayer):
@@ -175,11 +172,8 @@ class Multilayer(object):
 
     @property
     def bLayer(self):
-        if raycing.is_valid_uuid(self._bLayer) and self.bl is not None:
-            mat = self.bl.materialsDict.get(self._bLayer)
-        else:
-            mat = self._bLayer
-        return mat
+        return raycing.normalize_ref(
+            self._bLayer, self.bl, 'material', target='object')
 
     @bLayer.setter
     def bLayer(self, bLayer):
@@ -187,11 +181,8 @@ class Multilayer(object):
 
     @property
     def substrate(self):
-        if raycing.is_valid_uuid(self._substrate) and self.bl is not None:
-            mat = self.bl.materialsDict.get(self._substrate)
-        else:
-            mat = self._substrate
-        return mat
+        return raycing.normalize_ref(
+            self._substrate, self.bl, 'material', target='object')
 
     @substrate.setter
     def substrate(self, substrate):

--- a/xrt/backends/raycing/materials/volume.py
+++ b/xrt/backends/raycing/materials/volume.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
+from ... import raycing
 from ..physconsts import CHBAR
 from .material import Material
 
@@ -138,16 +139,8 @@ class TXMMaterial(Material):
             for i, v in enumerate(materialsIndex)}
 
     def _resolve_materials_index_entry(self, material):
-        if not isinstance(material, str):
-            return material
-
-        if self.bl is not None:
-            matId = self.bl.matnamesToUUIDs.get(material, material)
-            resolved = self.bl.materialsDict.get(matId)
-            if resolved is not None:
-                return resolved
-
-        return material
+        return raycing.normalize_ref(
+            material, self.bl, 'material', target='object')
 
     def reload(self, strict=False):
         """

--- a/xrt/backends/raycing/oes/base.py
+++ b/xrt/backends/raycing/oes/base.py
@@ -439,22 +439,11 @@ class OE(OEMainMethods):
 
     @property
     def material(self):
-        def resolve(mat):
-            if not raycing.is_valid_uuid(mat):
-                return mat
-
-            if self.bl is None:
-                print(f"Material with UUID {mat} doesn't exist!")
-                return None
-
-            return self.bl.materialsDict.get(mat)
-
-        m = self._material
-
-        if raycing.is_sequence(m):
-            return [resolve(x) for x in m]
-        else:
-            return resolve(m)
+        material = raycing.normalize_ref(
+            self._material, self.bl, 'material', target='object')
+        if raycing.is_sequence(self._material):
+            return list(material)
+        return material
 
     @material.setter
     def material(self, material):
@@ -462,15 +451,8 @@ class OE(OEMainMethods):
 
     @property
     def figureError(self):
-        if raycing.is_valid_uuid(self._figureError):
-            if self.bl is not None:
-                fe = self.bl.fesDict.get(self._figureError)
-            else:
-                fe = None
-                print(f"Figure Error instance with UUID {self._material} doesn't exist!")
-        else:
-            fe = self._figureError
-        return fe
+        return raycing.normalize_ref(
+            self._figureError, self.bl, 'figureError', target='object')
 
     @figureError.setter
     def figureError(self, figureError):

--- a/xrt/backends/raycing/oes/dcm.py
+++ b/xrt/backends/raycing/oes/dcm.py
@@ -141,22 +141,11 @@ class DCM(OE):
 
     @property
     def material2(self):
-        def resolve(mat):
-            if not raycing.is_valid_uuid(mat):
-                return mat
-
-            if self.bl is None:
-                print(f"Material with UUID {mat} doesn't exist!")
-                return None
-
-            return self.bl.materialsDict.get(mat)
-
-        m = self._material2
-
-        if raycing.is_sequence(m):
-            return [resolve(x) for x in m]
-        else:
-            return resolve(m)
+        material2 = raycing.normalize_ref(
+            self._material2, self.bl, 'material', target='object')
+        if raycing.is_sequence(self._material2):
+            return list(material2)
+        return material2
 
     @material2.setter
     def material2(self, material2):

--- a/xrt/backends/raycing/oes/laue.py
+++ b/xrt/backends/raycing/oes/laue.py
@@ -100,12 +100,8 @@ class BentLaueCylinder(OE):
         else:
             matSur = self._material
 
-        if raycing.is_valid_uuid(matSur) and self.bl is not None:
-            mat = self.bl.materialsDict.get(matSur)
-        else:
-            mat = matSur
-
-        return mat
+        return raycing.normalize_ref(
+            matSur, self.bl, 'material', target='object')
 
     @material.setter
     def material(self, material):
@@ -323,12 +319,8 @@ class BentLaue2D(OE):
         else:
             matSur = self._material
 
-        if raycing.is_valid_uuid(matSur) and self.bl is not None:
-            mat = self.bl.materialsDict.get(matSur)
-        else:
-            mat = matSur
-
-        return mat
+        return raycing.normalize_ref(
+            matSur, self.bl, 'material', target='object')
 
     @material.setter
     def material(self, material):

--- a/xrt/backends/raycing/oes/refractive.py
+++ b/xrt/backends/raycing/oes/refractive.py
@@ -49,18 +49,8 @@ class Plate(DCM):
 #        self.material2 = self.material
 
     def _resolve_material(self, mat):
-        if mat is None:
-            return None
-
-        if raycing.is_valid_uuid(mat) and self.bl is not None:
-            return self.bl.materialsDict.get(mat)
-
-        if isinstance(mat, str) and self.bl is not None and \
-                mat in self.bl.matnamesToUUIDs:
-            uuid = self.bl.matnamesToUUIDs.get(mat)
-            return self.bl.materialsDict.get(uuid)
-
-        return mat
+        return raycing.normalize_ref(
+            mat, self.bl, 'material', target='object')
 
     @property
     def t(self):

--- a/xrt/gui/xrtGlow/widgets/opengl.py
+++ b/xrt/gui/xrtGlow/widgets/opengl.py
@@ -633,19 +633,11 @@ class xrtGlWidget(qt.QOpenGLWidget):
                         arrayValue[idx] = argValue
                         argValue = arrayValue
 
-            elif arg0 == 'materialsIndex':
-                pass
-            elif any(arg0.lower().startswith(v) for v in
-                     ['mater', 'tlay', 'blay', 'coat', 'substrate']):
-                if not raycing.is_valid_uuid(argValue):
-                    # objects need material uuid rather than name
-                    argValue = self.beamline.matnamesToUUIDs.get(argValue)
-                    kwargs[arg0] = argValue
-            elif any(arg0.lower().startswith(v) for v in
-                     ['figureerr', 'basefe']):
-                if not raycing.is_valid_uuid(argValue):
-                    # objects need fe uuid rather than name
-                    argValue = self.beamline.fenamesToUUIDs.get(argValue)
+            else:
+                refKind = raycing.ref_kind_for_arg(arg0)
+                if refKind is not None:
+                    argValue = raycing.normalize_ref(
+                        argValue, self.beamline, refKind, target='uuid')
                     kwargs[arg0] = argValue
 
             # updating local beamline tree here

--- a/xrt/plotter.py
+++ b/xrt/plotter.py
@@ -57,6 +57,16 @@ from matplotlib.ticker import MaxNLocator
 from . import runner
 # from runner import runCardVals, runCardProcs
 from .backends import raycing
+
+_RAYCING_BEAM_FIELDS = {field.lower(): field for field in raycing.allBeamFields}
+
+
+def _label_tokens(label):
+    for char in "$_\\'\".,;:()[]{}<>+-=*/|":
+        label = label.replace(char, ' ')
+    return set(label.split())
+
+
 try:
     from .gui.commons import qt
     hasQt = True
@@ -271,23 +281,38 @@ class XYCAxis(object):
                 polarization properties. Alternatively, you may pass an array
                 of the length of the beam arrays.
 
+                .. note::
+
+                    In Shadow, x', y' and z' are stored ray direction
+                    components (often described as direction or divergence).
+                    Their direct raycing analogs are a, b and c. For
+                    convenience and historical compatibility, raycing
+                    auto-assigns x' and z' to the slopes a/b and c/b, i.e. to
+                    raycing.get_xprime and raycing.get_zprime. The label y' has
+                    no analogous slope definition because b is the reference
+                    direction; it is therefore auto-assigned to raycing.get_b.
+
                 =======  ===================================================
                  x       raycing.get_x
                  y       raycing.get_y
                  z       raycing.get_z
-                 x'      raycing.get_xprime
-                 z'      raycing.get_zprime
+                 x'      raycing.get_xprime = a/b
+                 y'      raycing.get_b
+                 z'      raycing.get_zprime = c/b
                  energy  raycing.get_energy
                 =======  ===================================================
 
             If *data* = 'auto' then *label* is searched for "x", "y", "z",
-            "x'", "z'", "energy" and if one of them is found, *data* is
-            assigned to the listed above index or function. In raycing backend
-            the automatic assignment is additionally implemented for *label*
-            containing 'degree (for degree of polarization)', 'circular' (for
-            circular polarization rate), 'path', 'incid' or 'theta' (for
-            incident angle), 'order' (for grating diffraction order), 's',
-            'phi', 'r' or 's' (for parametric representation of OE).
+            "x'", "y'", "z'", "energy" and if one of them is found, *data* is
+            assigned to the listed above index or function. In raycing backend,
+            automatic assignment first checks whether a corresponding
+            ``get_<label>`` function exists and then falls back to matching
+            labels containing 'degree (for degree of polarization)', 'circular'
+            (for circular polarization rate), 'polarization' and 'angle' (for
+            angle of polarization ellipse), 'ellipse' or 'axes' (for ratio of
+            ellipse axes), 'phase', 'path', 'incid' or 'theta' (for incident
+            angle), 'order' (for grating diffraction order), and standalone
+            's', 'phi', 'r', 'a' or 'b'.
 
         *limits*: 2-list of floats [min, max]
             Axis limits. If None, the *limits* are taken as ``np.min`` and
@@ -506,6 +531,11 @@ class XYCAxis(object):
                 data = 5
             elif backend == 'raycing':
                 data = raycing.get_zprime
+        elif lbl in ["y'", "yprime"]:
+            if backend == 'shadow':
+                data = 4
+            elif backend == 'raycing':
+                data = raycing.get_b
         elif lbl in ["x"]:
             if backend == 'shadow':
                 data = 0
@@ -521,8 +551,36 @@ class XYCAxis(object):
                 data = 2
             elif backend == 'raycing':
                 data = raycing.get_z
-        elif lbl in raycing.allBeamFields:
-            data = getattr(raycing, 'get_{}'.format(lbl))
+        elif backend == 'raycing' and lbl in _RAYCING_BEAM_FIELDS:
+            data = getattr(raycing, 'get_{}'.format(
+                _RAYCING_BEAM_FIELDS[lbl]))
+        elif backend == 'raycing' and "degree" in lbl:
+            data = raycing.get_polarization_degree
+        elif backend == 'raycing' and "circular" in lbl:
+            data = raycing.get_circular_polarization_rate
+        elif backend == 'raycing' and "polarization" in lbl and\
+                "angle" in lbl:
+            data = raycing.get_polarization_psi
+        elif backend == 'raycing' and ("ellipse" in lbl or "axes" in lbl):
+            data = raycing.get_ratio_ellipse_axes
+        elif backend == 'raycing' and "phase" in lbl:
+            data = raycing.get_phase_shift
+        elif backend == 'raycing' and ("incid" in lbl or "theta" in lbl):
+            data = raycing.get_incidence_angle
+        elif backend == 'raycing' and "phi" in lbl:
+            data = raycing.get_phi
+        elif backend == 'raycing' and "order" in lbl:
+            data = raycing.get_order
+        elif backend == 'raycing' and "path" in lbl:
+            data = raycing.get_path
+        elif backend == 'raycing' and "s" in _label_tokens(lbl):
+            data = raycing.get_s
+        elif backend == 'raycing' and "r" in _label_tokens(lbl):
+            data = raycing.get_r
+        elif backend == 'raycing' and "a" in _label_tokens(lbl):
+            data = raycing.get_a
+        elif backend == 'raycing' and "b" in _label_tokens(lbl):
+            data = raycing.get_b
         else:
             raise ValueError(
                 'cannot auto-assign data for axis "{0}"!'.format(self.label))


### PR DESCRIPTION
This change centralizes conversion between human-readable names, UUIDs, and runtime objects for raycing references such as materials, figure errors, and optical elements.

The main intent is to make GUI editing, layout import/export, code generation, and runtime updates use the same reference-resolution path instead of repeating local special cases.

Included changes:
- add shared reference normalization helpers
- apply normalization in beamline layout loading and runtime update paths
- preserve object-safe behavior for material and figure-error properties
- update multilayer/material reference handling to use the shared path
- fix reference cleanup on material and figure-error deletion
- add regression tests for reference bookkeeping and property behavior
- update affected examples and add a smoke runner for raycing examples

This also includes small follow-up fixes discovered while testing:
- synchronize aperture blades when legacy opening values are changed
- update one Balder example to use explicit blades
- fix generator argument order in the bent Laue analyzer example
- improve plot axis auto-assignment for raycing labels, including `y'`