### PR TITLE
Dict property editor widget

### DIFF
--- a/xrt/backends/raycing/__init__.py
+++ b/xrt/backends/raycing/__init__.py
@@ -226,6 +226,8 @@ from ._flow_utils import (
     append_to_flow_decorator, set_name, vec_to_quat, multiply_quats,
     quat_vec_rotate, get_init_val, get_params, parametrize,
     normalize_ref, ref_kind_for_arg,
+    get_argument_editor_hint, parse_editor_mapping, format_editor_scalar,
+    serialize_editor_value,
     create_paramdict_oe, create_paramdict_mat, get_obj_str, get_init_kwargs,
     is_valid_uuid, run_process_from_file, build_hist, parse_energy_string,
     is_auto_align_value, get_auto_align_energy, format_energy_input,

--- a/xrt/backends/raycing/_flow_utils.py
+++ b/xrt/backends/raycing/_flow_utils.py
@@ -39,6 +39,27 @@ safe_globals = {
 }
 
 
+def _class_from_string(objStr):
+    moduleName, className = str(objStr).rsplit('.', 1)
+    module = importlib.import_module(moduleName)
+    return getattr(module, className)
+
+
+def get_argument_editor_hint(objRef, argName):
+    if objRef is None:
+        return None
+    try:
+        if isinstance(objRef, str):
+            objRef = _class_from_string(objRef)
+        hintFunc = getattr(objRef, 'get_argument_editor_hint', None)
+        if hintFunc is None:
+            return None
+        hint = hintFunc(argName)
+    except Exception:
+        return None
+    return hint if isinstance(hint, dict) else None
+
+
 class NameAsString(ast.NodeTransformer):
     """Replace unknown names with string literals."""
     def __init__(self, allowed_names):
@@ -339,6 +360,12 @@ def get_params(objStr):  # Returns a collection of default parameters
                         for arg, argVal in zip(argnames, argdefaults):
                             if arg == 'bl':
                                 argVal = None
+                            editorHint = get_argument_editor_hint(
+                                objRef, arg)
+                            if argVal is None and isinstance(
+                                    editorHint, dict) and\
+                                    'default' in editorHint:
+                                argVal = editorHint['default']
                             if arg not in args and arg not in hpList:
                                 uArgs[arg] = argVal
                     if namef == "__init__" or namef.endswith("pop_kwargs"):
@@ -538,6 +565,57 @@ def normalize_ref(value, bl=None, refKind='material', target='uuid'):
             return obj if obj is not None else (
                 None if bl is not None else value)
         return value
+
+
+def parse_editor_mapping(value):
+    if value is None or (isinstance(value, basestring) and
+                         value in ['', 'None']):
+        return {}
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, (list, tuple)):
+        return {i: item for i, item in enumerate(value)}
+    try:
+        parsed = parametrize(value)
+    except Exception:
+        parsed = value
+    if parsed is None or (isinstance(parsed, basestring) and
+                          parsed in ['', 'None']):
+        return {}
+    if isinstance(parsed, dict):
+        return dict(parsed)
+    if isinstance(parsed, (list, tuple)):
+        return {i: item for i, item in enumerate(parsed)}
+    return {}
+
+
+def format_editor_scalar(value, valueHint=None, bl=None,
+                         quote_strings=True):
+    valueHint = {} if valueHint is None else dict(valueHint)
+    if value is None:
+        return 'None'
+    if valueHint.get('editor') == 'reference':
+        refKind = valueHint.get('refKind', 'material')
+        value = normalize_ref(value, bl, refKind, target='display')
+        if value is None:
+            return 'None'
+        text = str(value)
+        if not quote_strings:
+            return text
+        return text if text.isidentifier() else repr(text)
+    return repr(value) if quote_strings else str(value)
+
+
+def serialize_editor_value(value, hint=None, bl=None):
+    if not isinstance(hint, dict) or hint.get('editor') != 'dict':
+        return str(value)
+    valueHint = dict(hint.get('valueHint') or {})
+    mapping = parse_editor_mapping(value)
+    items = []
+    for key, itemValue in mapping.items():
+        items.append('{0}: {1}'.format(
+            repr(key), format_editor_scalar(itemValue, valueHint, bl)))
+    return '{' + ', '.join(items) + '}'
 
 
 def _parametrize_reference(value, bl=None, refKind='material'):

--- a/xrt/backends/raycing/figure_error.py
+++ b/xrt/backends/raycing/figure_error.py
@@ -421,6 +421,9 @@ class FigureErrorImported(FigureErrorBase):
         self.nx, self.ny = len(self.x1d), len(self.y1d)
         self.x2d, self.y2d = np.meshgrid(self.x1d, self.y1d)
         self.z2d = np.zeros((self.ny, self.nx))
+        self.local_z_spline = interpolate.RectBivariateSpline(
+            self.y1d, self.x1d, self.z2d,
+            kx=self.splineOrder, ky=self.splineOrder)
         self.get_angles()
 
     def get_grids(self):

--- a/xrt/backends/raycing/materials/volume.py
+++ b/xrt/backends/raycing/materials/volume.py
@@ -51,7 +51,23 @@ class TXMMaterial(Material):
         'kind', 'elements', 'quantities', 'rho', 't', 'table', 'efficiency',
         'efficiencyFile', 'refractiveIndex')
 
-    def __init__(self, fileName='', materialsIndex=None, name='', **kwargs):
+    @staticmethod
+    def get_argument_editor_hint(argName):
+        if str(argName).lower() == 'materialsindex':
+            return {
+                'editor': 'dict',
+                'keyType': 'int',
+                'keyHeader': 'Index',
+                'valueHeader': 'Material',
+                'valueHint': {
+                    'editor': 'reference',
+                    'refKind': 'material',
+                    },
+                'default': {},
+                }
+        return None
+
+    def __init__(self, fileName=None, materialsIndex=None, name='', **kwargs):
         r"""
         *fileName*: str
             Path to the indexed-volume HDF5 file.
@@ -79,14 +95,14 @@ class TXMMaterial(Material):
         Material.__init__(
             self, elements=(), quantities=(), kind='plate', rho=0, t=None,
             name=name, refractiveIndex=1., **kwargs)
-        self._fileName = ''
+        self._fileName = None
         self._materialsIndex = {}
         self._materialsIndexError = None
         self._activeMaterialsIndex = {}
         self.isLoaded = False
         self.loadError = None
-        self.fileName = fileName
         self.materialsIndex = materialsIndex
+        self.fileName = fileName
 
     @property
     def kind(self):
@@ -104,7 +120,7 @@ class TXMMaterial(Material):
 
     @fileName.setter
     def fileName(self, fileName):
-        self._fileName = fileName or ''
+        self._fileName = fileName or None
         if hasattr(self, '_materialsIndex'):
             self.reload()
 
@@ -142,6 +158,13 @@ class TXMMaterial(Material):
         return raycing.normalize_ref(
             material, self.bl, 'material', target='object')
 
+    def _update_materials_index_keys(self, volume):
+        required = set(np.unique(volume['indexGrid']))
+        required.add(volume['backgroundIndex'])
+        self._materialsIndex = {
+            int(index): self._materialsIndex.get(int(index))
+            for index in sorted(required)}
+
     def reload(self, strict=False):
         """
         Reload and validate the configured indexed volume.
@@ -153,12 +176,12 @@ class TXMMaterial(Material):
         *strict*: bool
             If True, raise an exception for missing or invalid configuration.
         """
-        if not self.fileName or not self.materialsIndex:
+        if not self.fileName:
             self.isLoaded = False
             self.loadError = None
             if strict:
                 raise ValueError(
-                    'TXMMaterial requires fileName and materialsIndex')
+                    'TXMMaterial requires fileName')
             return False
         if self._materialsIndexError is not None:
             self.loadError = self._materialsIndexError
@@ -168,6 +191,15 @@ class TXMMaterial(Material):
 
         try:
             volume = self._read_volume_file(self.fileName)
+            self._update_materials_index_keys(volume)
+            if any(material is None
+                   for material in self.materialsIndex.values()):
+                self.isLoaded = False
+                self.loadError = None
+                if strict:
+                    raise ValueError(
+                        'TXMMaterial requires all materialsIndex entries')
+                return False
             self._validate_materials_index(
                 volume['indexGrid'], volume['backgroundIndex'],
                 self.materialsIndex)

--- a/xrt/gui/commons/qt.py
+++ b/xrt/gui/commons/qt.py
@@ -30,6 +30,10 @@ from qtpy.QtSql import (QSqlDatabase, QSqlQuery, QSqlTableModel,
                         QSqlQueryModel)
 
 
+RAW_VALUE_ROLE = Qt.UserRole + 1
+EDITOR_HINT_ROLE = Qt.UserRole + 2
+
+
 def _qt_attr(name, *modules):
     for module in modules:
         if hasattr(module, name):
@@ -89,6 +93,155 @@ glowSlider = mySlider
 glowTopScale = QSlider.TicksAbove
 
 
+class DictEditorDialog(QDialog):
+    def __init__(self, value=None, hint=None, bl=None, excludeRefs=None,
+                 parent=None):
+        super().__init__(parent)
+        self.hint = {} if hint is None else dict(hint)
+        self.valueHint = dict(self.hint.get('valueHint') or {})
+        self.bl = bl
+        self.excludeRefs = set(
+            str(ref) for ref in (excludeRefs or []) if ref is not None)
+        self.resultValue = None
+
+        self.setWindowTitle(self.hint.get('title', 'Edit values'))
+        self.resize(520, 360)
+
+        layout = QVBoxLayout(self)
+        self.table = QTableWidget(0, 2, self)
+        self.table.setHorizontalHeaderLabels([
+            self.hint.get('keyHeader', 'Key'),
+            self.hint.get('valueHeader', 'Value')])
+        self.table.horizontalHeader().setStretchLastSection(True)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.table.customContextMenuRequested.connect(self.show_context_menu)
+        layout.addWidget(self.table)
+
+        buttonsLayout = QHBoxLayout()
+        addButton = QPushButton('Add row', self)
+        addButton.clicked.connect(self.add_empty_row)
+        buttonsLayout.addWidget(addButton)
+        buttonsLayout.addStretch()
+        layout.addLayout(buttonsLayout)
+
+        self.buttonBox = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
+        self.buttonBox.accepted.connect(self.accept)
+        self.buttonBox.rejected.connect(self.reject)
+        layout.addWidget(self.buttonBox)
+
+        for key, itemValue in self._parse_value(value).items():
+            self.add_row(key, itemValue)
+        if self.table.rowCount() == 0:
+            self.add_empty_row()
+
+    def _parse_value(self, value):
+        from ...backends import raycing
+        return raycing.parse_editor_mapping(value)
+
+    def add_empty_row(self):
+        row = self.table.rowCount()
+        self.add_row(row, None)
+
+    def add_row(self, key, value):
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        self.table.setItem(row, 0, QTableWidgetItem(str(key)))
+        self._set_value_cell(row, value)
+
+    def _set_value_cell(self, row, value):
+        if self.valueHint.get('editor') == 'reference':
+            combo = QComboBox(self.table)
+            combo.setEditable(False)
+            combo.addItems(self._reference_items())
+            text = self._display_value(value)
+            idx = combo.findText(text)
+            if idx >= 0:
+                combo.setCurrentIndex(idx)
+            else:
+                combo.setEditText(text)
+            self.table.setCellWidget(row, 1, combo)
+        else:
+            self.table.setItem(row, 1, QTableWidgetItem(str(value)))
+
+    def _reference_items(self):
+        refKind = self.valueHint.get('refKind')
+        if refKind != 'material' or self.bl is None:
+            return ['None']
+        names = []
+        for name, uuid in sorted(getattr(
+                self.bl, 'matnamesToUUIDs', {}).items()):
+            if str(name) in self.excludeRefs or str(uuid) in self.excludeRefs:
+                continue
+            names.append(name)
+        return ['None'] + names
+
+    def _display_value(self, value):
+        from ...backends import raycing
+        return raycing.format_editor_scalar(
+            value, self.valueHint, self.bl, quote_strings=False)
+
+    def _parse_key(self, text):
+        keyType = str(self.hint.get('keyType', 'str')).lower()
+        if keyType == 'int':
+            return int(str(text).strip())
+        if keyType == 'float':
+            return float(str(text).strip())
+        return str(text)
+
+    def _cell_value(self, row):
+        widget = self.table.cellWidget(row, 1)
+        if isinstance(widget, QComboBox):
+            text = str(widget.currentText()).strip()
+        else:
+            item = self.table.item(row, 1)
+            text = '' if item is None else str(item.text()).strip()
+        if text in ['', 'None']:
+            return None
+        return text
+
+    def value(self):
+        out = {}
+        seen = set()
+        for row in range(self.table.rowCount()):
+            keyItem = self.table.item(row, 0)
+            if keyItem is None or not str(keyItem.text()).strip():
+                continue
+            key = self._parse_key(keyItem.text())
+            if key in seen:
+                raise ValueError('Duplicate key {0!r}'.format(key))
+            seen.add(key)
+            out[key] = self._cell_value(row)
+        return out
+
+    def serialized_value(self):
+        if self.resultValue is None:
+            self.resultValue = self.value()
+        from ...backends import raycing
+        return raycing.serialize_editor_value(
+            self.resultValue, self.hint, self.bl)
+
+    def show_context_menu(self, position):
+        index = self.table.indexAt(position)
+        if not index.isValid():
+            return
+        menu = QMenu(self.table)
+        removeAction = QAction('Remove row', self)
+        menu.addAction(removeAction)
+        removeAction.triggered.connect(
+            lambda: self.table.removeRow(index.row()))
+        menu.exec_(self.table.viewport().mapToGlobal(position))
+
+    def accept(self):
+        try:
+            self.resultValue = self.value()
+        except Exception as error:
+            QMessageBox.warning(self, 'Invalid values', str(error))
+            return
+        super().accept()
+
+
 class DynamicArgumentDelegate(QStyledItemDelegate):
     def __init__(self, nameToModel=None, parent=None, mainWidget=None,
                  bl=None):
@@ -96,6 +249,75 @@ class DynamicArgumentDelegate(QStyledItemDelegate):
         self.nameToModel = nameToModel
         self.mainWidget = mainWidget
         self.bl = bl
+
+    def argumentEditorHint(self, index, argName):
+        model = index.model()
+        if hasattr(model, 'itemFromIndex'):
+            valueItem = model.itemFromIndex(index)
+            if valueItem is not None:
+                hint = valueItem.data(EDITOR_HINT_ROLE)
+                if isinstance(hint, dict):
+                    return hint
+            keyItem = model.itemFromIndex(model.index(
+                index.row(), 0, index.parent()))
+            if keyItem is not None:
+                hint = keyItem.data(EDITOR_HINT_ROLE)
+                if isinstance(hint, dict):
+                    return hint
+        if self.mainWidget is not None and\
+                hasattr(self.mainWidget, 'getArgumentEditorHint'):
+            hint = self.mainWidget.getArgumentEditorHint(argName, index)
+            if isinstance(hint, dict):
+                return hint
+        return None
+
+    def _indexRawValue(self, index):
+        model = index.model()
+        if hasattr(model, 'itemFromIndex'):
+            item = model.itemFromIndex(index)
+            if item is not None:
+                rawValue = item.data(RAW_VALUE_ROLE)
+                if rawValue is not None:
+                    return rawValue
+        return index.data()
+
+    def _beamLine(self):
+        if self.bl is not None:
+            return self.bl
+        if self.mainWidget is not None:
+            bl = getattr(self.mainWidget, 'beamLine', None)
+            if bl is not None:
+                return bl
+            customGlWidget = getattr(self.mainWidget, 'customGlWidget', None)
+            bl = getattr(customGlWidget, 'beamline', None)
+            if bl is not None:
+                return bl
+        return None
+
+    def _excludedReferenceValues(self, index, hint):
+        valueHint = (hint or {}).get('valueHint') or {}
+        if valueHint.get('refKind') != 'material':
+            return set()
+
+        editorObject = getattr(self.mainWidget, 'editorObject', None)
+        uuid = getattr(editorObject, 'uuid', None)
+        if uuid is not None:
+            return {uuid}
+
+        bl = self._beamLine()
+        if bl is None or not hasattr(index.model(), 'itemFromIndex'):
+            return set()
+
+        item = index.model().itemFromIndex(index)
+        while item is not None and item.parent() is not None:
+            item = item.parent()
+        if item is None:
+            return set()
+
+        uuid = item.data(Qt.UserRole)
+        if str(uuid) in getattr(bl, 'materialsDict', {}):
+            return {uuid}
+        return set()
 
     def createEditor(self, parent, option, index):
         # TODO: split into oe/mat/plot
@@ -117,6 +339,13 @@ class DynamicArgumentDelegate(QStyledItemDelegate):
         # beamModel - only in propagation and plots
         # fluxLabels - only in plots
         # units - only in plots
+
+        editorHint = self.argumentEditorHint(index, argName)
+        if editorHint is not None and editorHint.get('editor') == 'dict':
+            btn = QPushButton('Edit...', parent)
+            btn.clicked.connect(partial(self.openDictDialog, index,
+                                        editorHint))
+            return btn
 
         combo = QComboBox(parent)
         combo.activated.connect(lambda: self.commitData.emit(combo))
@@ -172,8 +401,6 @@ class DynamicArgumentDelegate(QStyledItemDelegate):
 #            combo.setEditable(True)
 #            combo.setInsertPolicy(QComboBox.InsertAtCurrent)
 #            return combo
-        elif argNameL == 'materialsindex':
-            return QLineEdit(parent)
         elif any(argNameL.startswith(v) for v in
                  ['mater', 'tlay', 'blay', 'coat', 'substrate']):  # mat and bl
             currentElement = None
@@ -421,6 +648,8 @@ class DynamicArgumentDelegate(QStyledItemDelegate):
                 editor.setEditText(value)
         elif isinstance(editor, QLineEdit):
             editor.setText(value)
+        elif isinstance(editor, QPushButton):
+            editor.setText('Edit...')
 #        elif isinstance(editor, QWidget):  # TODO: need better condition
         elif editor.property('fieldName') == 'kind':
             for cb in editor.cb:
@@ -434,6 +663,8 @@ class DynamicArgumentDelegate(QStyledItemDelegate):
             model.setData(index, editor.currentText())
         elif isinstance(editor, QLineEdit):
             model.setData(index, editor.text())
+        elif isinstance(editor, QPushButton):
+            pass
         elif editor.property('fieldName') == 'kind':
             text = "["
             for cb in editor.cb:
@@ -473,6 +704,19 @@ class DynamicArgumentDelegate(QStyledItemDelegate):
             openFileName = openDialog.selectedFiles()[0]
             if openFileName:
                 index.model().setData(index, openFileName)
+
+    def openDictDialog(self, index, hint):
+        dialog = DictEditorDialog(
+            self._indexRawValue(index), hint, bl=self._beamLine(),
+            excludeRefs=self._excludedReferenceValues(index, hint),
+            parent=self.parent())
+        if dialog.exec_():
+            valueText = dialog.serialized_value()
+            if hasattr(index.model(), 'itemFromIndex'):
+                item = index.model().itemFromIndex(index)
+                if item is not None:
+                    item.setData(valueText, RAW_VALUE_ROLE)
+            index.model().setData(index, valueText)
 
 
 class MultiColumnFilterProxy(QSortFilterProxyModel):

--- a/xrt/gui/xrtGlow/widgets/inspector.py
+++ b/xrt/gui/xrtGlow/widgets/inspector.py
@@ -66,6 +66,8 @@ class InstanceInspector(qt.QDialog):
         elementId = dataDict.get('uuid')
         self.elementId = elementId
         self.elementName = dataDict.get('name', elementId)
+        self.beamLine = beamLine
+        self.editorObject = self.editor_object(elementId)
         epicsTree = None
         if epicsDict:
             epicsTree = epicsDict.pv_map.get(elementId)
@@ -196,7 +198,6 @@ class InstanceInspector(qt.QDialog):
         layoutL = qt.QVBoxLayout(widgetL)
         layoutL.addWidget(self.table)
         layoutL.addWidget(self.button_box)
-        self.beamLine = beamLine
 
         if self.beamLine is None:
             layout.addWidget(widgetL)
@@ -290,6 +291,20 @@ class InstanceInspector(qt.QDialog):
         self.edited_data = {}
         self.scanItems = []
 
+    def editor_object(self, elementId):
+        if self.beamLine is None:
+            return None
+        if elementId in self.beamLine.oesDict:
+            return self.beamLine.oesDict[elementId][0]
+        if elementId in self.beamLine.materialsDict:
+            return self.beamLine.materialsDict[elementId]
+        if elementId in self.beamLine.fesDict:
+            return self.beamLine.fesDict[elementId]
+        return None
+
+    def getArgumentEditorHint(self, argName, index=None):
+        return raycing.get_argument_editor_hint(self.editorObject, argName)
+
     def add_blades_params(self, parentItem, value, epicsTree):
         blades = value if isinstance(value, dict) else\
             raycing.parametrize(value)
@@ -341,7 +356,18 @@ class InstanceInspector(qt.QDialog):
         toolTip = None
         child0 = qt.QStandardItem(str(paramName))
         child0.setFlags(self.paramFlag)
-        child1 = qt.QStandardItem(str(value))
+        editorHint = self.getArgumentEditorHint(paramName)
+        rawValue = raycing.serialize_editor_value(
+            value, editorHint, getattr(self, 'beamLine', None))
+        if isinstance(editorHint, dict) and editorHint.get('editor') == 'dict':
+            displayValue = rawValue
+        else:
+            displayValue = str(value)
+        child1 = qt.QStandardItem(displayValue)
+        child1.setData(rawValue, qt.RAW_VALUE_ROLE)
+        if editorHint is not None:
+            child0.setData(editorHint, qt.EDITOR_HINT_ROLE)
+            child1.setData(editorHint, qt.EDITOR_HINT_ROLE)
 
         if str(paramName) == 'name' or paramName.endswith('rbk') or\
                 parent is self.itemGroups.get('Diagnostic'):

--- a/xrt/gui/xrtGlow/widgets/inspector.py
+++ b/xrt/gui/xrtGlow/widgets/inspector.py
@@ -1693,7 +1693,13 @@ class SurfacePlotWidget(qt.QWidget):
         self.toolbar = qt.NavigationToolbar(self.canvas, self)
 
         layout = qt.QVBoxLayout(self)
-        layout.addWidget(self.toolbar)
+        toolbarLayout = qt.QHBoxLayout()
+        toolbarLayout.addWidget(self.toolbar)
+        toolbarLayout.addStretch()
+        self.exportButton = qt.QPushButton("Export surface...", self)
+        self.exportButton.clicked.connect(self.export_surface)
+        toolbarLayout.addWidget(self.exportButton)
+        layout.addLayout(toolbarLayout)
         layout.addWidget(self.canvas)
 
         self.surface = None
@@ -1744,3 +1750,35 @@ class SurfacePlotWidget(qt.QWidget):
         self.ax.set_zlabel("Z [nm]")
 
         self.canvas.draw_idle()
+
+    def export_surface(self):
+        if self.beamLine is None:
+            return
+        surfObj = self.beamLine.fesDict.get(self.elementId)
+        if surfObj is None or not hasattr(surfObj, 'local_z_distorted'):
+            return
+
+        fileName = re.sub(r'[^a-zA-Z0-9_\-.]+', '_', surfObj.name)
+        saveDialog = qt.QFileDialog()
+        saveDialog.setFileMode(qt.QFileDialog.AnyFile)
+        saveDialog.setAcceptMode(qt.QFileDialog.AcceptSave)
+        saveDialog.setNameFilter("DAT files (*.dat);;All files (*)")
+        saveDialog.selectNameFilter("DAT files (*.dat)")
+        saveDialog.selectFile("{0}.dat".format(fileName))
+        if not saveDialog.exec_():
+            return
+
+        fileName = saveDialog.selectedFiles()[0]
+        if not fileName.lower().endswith('.dat'):
+            fileName = "{0}.dat".format(fileName)
+
+        x = getattr(surfObj, 'x2d', None)
+        y = getattr(surfObj, 'y2d', None)
+        if x is None or y is None:
+            return
+        z = surfObj.local_z_distorted(x, y) * 1e6
+        data = np.column_stack((x.ravel(), y.ravel(), z.ravel()))
+        try:
+            np.savetxt(fileName, data)
+        except Exception as e:
+            print(e)

--- a/xrt/gui/xrtGlow/widgets/main.py
+++ b/xrt/gui/xrtGlow/widgets/main.py
@@ -408,20 +408,11 @@ class xrtGlow(qt.QWidget):
             for argName, argValue in oeProps.items():
                 if hasattr(oeObj, f'_{argName}Init'):
                     oeInitProps[argName] = getattr(oeObj, f'_{argName}Init')
-                if any(argName.lower().startswith(v) for v in
-                        ['mater', 'tlay', 'blay', 'coat', 'substrate']) and\
-                        raycing.is_valid_uuid(argValue):
-                    argMat = self.customGlWidget.beamline.materialsDict.get(
-                            argValue)
-                    if argMat is not None:
-                        oeProps[argName] = argMat.name
-                if any(argName.lower().startswith(v) for v in
-                        ['figureer', 'basefe']) and\
-                        raycing.is_valid_uuid(argValue):
-                    argFE = self.customGlWidget.beamline.fesDict.get(
-                            argValue)
-                    if argFE is not None:
-                        oeProps[argName] = argFE.name
+                refKind = raycing.ref_kind_for_arg(argName)
+                if refKind is not None:
+                    oeProps[argName] = raycing.normalize_ref(
+                        argValue, self.customGlWidget.beamline, refKind,
+                        target='display')
 
             catDict = {'Position': raycing.orientationArgSet}
             if oeType == 0:  # source

--- a/xrt/gui/xrtGlow/widgets/opengl.py
+++ b/xrt/gui/xrtGlow/widgets/opengl.py
@@ -642,9 +642,18 @@ class xrtGlWidget(qt.QOpenGLWidget):
 
             # updating local beamline tree here
             setattr(updObj, arg0, argValue)
+            if obj_type == "mat" and arg0 == "name":
+                for matName, matId in list(
+                        self.beamline.matnamesToUUIDs.items()):
+                    if matId == oeid:
+                        del self.beamline.matnamesToUUIDs[matName]
+                self.beamline.matnamesToUUIDs[str(updObj.name)] = oeid
 
             if sender == 'OEE':
-                self.updateQookTree.emit((oeid, {arg0: argValue}))
+                updatedArgs = {arg0: getattr(updObj, arg0)}
+                if arg0 == 'fileName' and hasattr(updObj, 'materialsIndex'):
+                    updatedArgs['materialsIndex'] = updObj.materialsIndex
+                self.updateQookTree.emit((oeid, updatedArgs))
             if obj_type == "oe":
                 meshUpdateQueued = False
                 renderUpdateQueued = False

--- a/xrt/gui/xrtQook/widgets/qook.py
+++ b/xrt/gui/xrtQook/widgets/qook.py
@@ -392,19 +392,15 @@ class XrtQook(XrtQookElements):
                             pNItem = pItem.child(k, 0)
                             for argName, argValue in kwargs.items():
                                 if str(pNItem.text()) == argName:
-                                    if any(argName.lower().startswith(v) for v in
-                                           ['mater', 'tlay', 'blay', 'coat', 'substrate']) and\
-                                        raycing.is_valid_uuid(argValue):
-                                            matObj = self.beamLine.materialsDict.get(argValue)
-                                            argValue = matObj.name
-                                    elif any(argName.lower().startswith(v) for v in
-                                           ['figureerr', 'basefe']):
-                                        if raycing.is_valid_uuid(argValue):
-                                            feObj = self.beamLine.fesDict.get(argValue)
-                                            argValue = feObj.name
+                                    refKind = raycing.ref_kind_for_arg(argName)
+                                    if refKind is not None:
+                                        argValue = raycing.normalize_ref(
+                                            argValue, self.beamLine, refKind,
+                                            target='display')
 
                                     pVItem = pItem.child(k, 1)
-                                    pVItem.setText(str(argValue))
+                                    self.setParamItemValue(
+                                        pVItem, argName, argValue)
                         break
                 break
         model.blockSignals(False)
@@ -426,17 +422,38 @@ class XrtQook(XrtQookElements):
         paintItem = self.rootMatItem.child(matItem.row(), 1)
         # renaming existing
         if item.column() == 1 and item.text() == matItem.text():
-            self.beamLine.materialsDict[matId].name = item.text()
+            matObj = self.beamLine.materialsDict[matId]
+            oldName = matObj.name
+            matObj.name = item.text()
+            self.beamLine.matnamesToUUIDs.pop(oldName, None)
+            self.beamLine.matnamesToUUIDs[str(item.text())] = matId
             return
 
         parent = item.parent()
 
         if item.column() == 1:  # Existing Element
-            argValue_str = item.text()
+            argValue_str = self.getParamItemValue(item)
             argName = parent.child(item.row(), 0).text()
             argValue = raycing.parametrize(argValue_str)
+            matObj = self.beamLine.materialsDict.get(matId)
+            if matObj is not None:
+                setattr(matObj, argName, argValue)
 
             kwargs[argName] = argValue
+            if argName == 'fileName' and hasattr(matObj, 'materialsIndex'):
+                kwargs['materialsIndex'] = matObj.materialsIndex
+                for i in range(parent.rowCount()):
+                    keyItem = parent.child(i, 0)
+                    if str(keyItem.text()) == 'materialsIndex':
+                        signalsBlocked = item.model().signalsBlocked()
+                        item.model().blockSignals(True)
+                        try:
+                            self.setParamItemValue(
+                                parent.child(i, 1), 'materialsIndex',
+                                matObj.materialsIndex)
+                        finally:
+                            item.model().blockSignals(signalsBlocked)
+                        break
             outDict = kwargs
 
         elif item.column() == 0:  # New Element
@@ -446,7 +463,8 @@ class XrtQook(XrtQookElements):
                     for iprop in range(chitem.rowCount()):
                         argName = chitem.child(iprop, 0).text()
                         argValue = raycing.parametrize(
-                                chitem.child(iprop, 1).text())
+                                self.getParamItemValue(
+                                    chitem.child(iprop, 1)))
                         kwargs[str(argName)] = argValue
                 elif chitem.text() == '_object':
                     objStr = str(matItem.child(itop, 1).text())
@@ -489,7 +507,7 @@ class XrtQook(XrtQookElements):
         parent = item.parent()
 
         if item.column() == 1:  # Existing Element
-            argValue_str = item.text()
+            argValue_str = self.getParamItemValue(item)
             argName = parent.child(item.row(), 0).text()
             argValue = raycing.parametrize(argValue_str)
 
@@ -503,7 +521,8 @@ class XrtQook(XrtQookElements):
                     for iprop in range(chitem.rowCount()):
                         argName = chitem.child(iprop, 0).text()
                         argValue = raycing.parametrize(
-                                chitem.child(iprop, 1).text())
+                                self.getParamItemValue(
+                                    chitem.child(iprop, 1)))
                         kwargs[str(argName)] = argValue
                 elif chitem.text() == '_object':
                     objStr = str(feItem.child(itop, 1).text())
@@ -539,7 +558,8 @@ class XrtQook(XrtQookElements):
                 if str(mchi.text()) == 'parameters':
                     for mchpi in range(mchi.rowCount()):
                         argName = str(mchi.child(mchpi, 0).text())
-                        argValue = str(mchi.child(mchpi, 1).text())
+                        argValue = self.getParamItemValue(
+                            mchi.child(mchpi, 1))
                         if argName == 'beam':
                             argValue = beamToUuid(argValue)
                         else:
@@ -549,7 +569,8 @@ class XrtQook(XrtQookElements):
                 elif str(mchi.text()) == 'output':
                     for mchpi in range(mchi.rowCount()):
                         argName = str(mchi.child(mchpi, 0).text())
-                        argValue = str(mchi.child(mchpi, 1).text())
+                        argValue = self.getParamItemValue(
+                            mchi.child(mchpi, 1))
                         if argName == 'beam':
                             argValue = beamToUuid(argValue)
                         else:
@@ -596,8 +617,7 @@ class XrtQook(XrtQookElements):
                 oeid = str(item.data(qt.Qt.UserRole))
 
             if column == 1:  # Existing Element
-                item.setData(str(item.text()), qt.Qt.UserRole + 1)
-                argValue_str = item.text()
+                argValue_str = self.getParamItemValue(item)
                 argName = parent.child(row, 0).text()
 
                 if argName == 'beam':
@@ -640,7 +660,8 @@ class XrtQook(XrtQookElements):
                             for iprop in range(chitem.rowCount()):
                                 argName = chitem.child(iprop, 0).text()
                                 argValue = raycing.parametrize(
-                                        chitem.child(iprop, 1).text())
+                                        self.getParamItemValue(
+                                            chitem.child(iprop, 1)))
                                 kwargs[str(argName)] = argValue
                         elif chitem.text() == '_object':
                             continue
@@ -694,7 +715,8 @@ import numpy as np\nimport sys\nsys.path.append(r\"{1}\")\n""".format(
                         blPropItem.rowCount()),
                         list(zip(*self.getParams(blstr)))[1]):
                     paraname = str(blPropItem.child(iep, 0).text())
-                    paravalue = str(blPropItem.child(iep, 1).text())
+                    paravalue = self.getParamItemValue(
+                        blPropItem.child(iep, 1))
                     if paravalue != str(arg_def):
                         paravalue = self.quotize(paravalue)
                         codeBuildBeamline += '\n{2}{0}={1},'.format(
@@ -741,12 +763,14 @@ if __name__ == '__main__':
                                         pItem.rowCount()),
                                         list(zip(*self.getParams(elstr)))[1]):
                                     paraname = str(pItem.child(iep, 0).text())
-                                    paravalue = str(pItem.child(iep, 1).text())
+                                    paravalue = self.getParamItemValue(
+                                        pItem.child(iep, 1))
                                     if paravalue != str(arg_def) or\
                                             paravalue == 'bl':
                                         if paraname.lower() not in\
                                                 ['tlayer', 'blayer',
-                                                 'coating', 'substrate']:
+                                                 'coating', 'substrate',
+                                                 'materialsindex']:
                                             paravalue = self.quotize(paravalue)
                                         ieinit += '\n{2}{0}={1},'.format(
                                             paraname, paravalue, myTab)
@@ -776,7 +800,8 @@ if __name__ == '__main__':
                                         pItem.rowCount()),
                                         list(zip(*self.getParams(elstr)))[1]):
                                     paraname = str(pItem.child(iep, 0).text())
-                                    paravalue = str(pItem.child(iep, 1).text())
+                                    paravalue = self.getParamItemValue(
+                                        pItem.child(iep, 1))
                                     if paravalue != str(arg_def) or\
                                             paravalue == 'bl':
                                         if paraname.lower() not in\
@@ -818,7 +843,8 @@ if __name__ == '__main__':
                             pItem.rowCount()),
                             list(zip(*self.getParams(elstr)))[1]):
                         paraname = str(pItem.child(iep, 0).text())
-                        paravalue = str(pItem.child(iep, 1).text())
+                        paravalue = self.getParamItemValue(
+                            pItem.child(iep, 1))
                         if paraname == 'center':
                             if paravalue.startswith('['):
                                 paravalue = re.findall(r'\[(.*)\]',
@@ -860,8 +886,8 @@ if __name__ == '__main__':
                                     getargspec(methodObj)[3]):
                                 paraname = str(
                                     mItem.child(iep, 0).text())
-                                paravalue = str(
-                                    mItem.child(iep, 1).text())
+                                paravalue = self.getParamItemValue(
+                                    mItem.child(iep, 1))
                                 if paravalue != str(arg_def):
                                     ierun += '\n{2}{0}={1},'.format(
                                         paraname, paravalue, myTab*2)
@@ -870,7 +896,8 @@ if __name__ == '__main__':
                             paraOutput = ""
                             paraOutBeams = []
                             for iep in range(mItem.rowCount()):
-                                paravalue = mItem.child(iep, 1).text()
+                                paravalue = self.getParamItemValue(
+                                    mItem.child(iep, 1))
                                 paraOutBeams.append(str(paravalue))
                                 outBeams.append(str(paravalue))
                                 paraOutput += str(paravalue)+", "

--- a/xrt/gui/xrtQook/widgets/qookbase.py
+++ b/xrt/gui/xrtQook/widgets/qookbase.py
@@ -723,18 +723,10 @@ class XrtQookBase(qt.QMainWindow):
         for argName, argValue in oeProps.items():
             if hasattr(oeObj, f'_{argName}Init'):
                 oeInitProps[argName] = getattr(oeObj, f'_{argName}Init')
-            if any(argName.lower().startswith(v) for v in
-                    ['mater', 'tlay', 'blay', 'coat', 'substrate']) and\
-                    raycing.is_valid_uuid(argValue):
-                argMat = self.beamLine.materialsDict.get(argValue)
-                if hasattr(argMat, 'name'):
-                    oeProps[argName] = argMat.name
-            if any(argName.lower().startswith(v) for v in
-                    ['figureerror']) and\
-                    raycing.is_valid_uuid(argValue):
-                argFE = self.beamLine.fesDict.get(argValue)
-                if hasattr(argFE, 'name'):
-                    oeProps[argName] = argFE.name
+            refKind = raycing.ref_kind_for_arg(argName)
+            if refKind is not None:
+                oeProps[argName] = raycing.normalize_ref(
+                    argValue, self.beamLine, refKind, target='display')
 
         catDict = {'Position': raycing.orientationArgSet}
         if oeType == 0:  # source
@@ -789,12 +781,10 @@ class XrtQookBase(qt.QMainWindow):
                                            blname=blName)
         matProps.update({'uuid': matuuid})
         for argName, argValue in matProps.items():
-            if any(argName.lower().startswith(v) for v in
-                    ['mater', 'tlay', 'blay', 'coat', 'substrate']) and\
-                   raycing.is_valid_uuid(str(argValue)):
-                argMat = self.beamLine.materialsDict.get(argValue)
-                if hasattr(argMat, 'name'):
-                    matProps[argName] = argMat.name
+            refKind = raycing.ref_kind_for_arg(argName)
+            if refKind is not None:
+                matProps[argName] = raycing.normalize_ref(
+                    argValue, self.beamLine, refKind, target='display')
         glowObj = getattr(self, 'blViewer', None)
         glWidget = getattr(glowObj, 'customGlWidget', None)
         matViewer = InstanceInspector(self, matProps, beamLine=self.beamLine,
@@ -838,12 +828,10 @@ class XrtQookBase(qt.QMainWindow):
         surfProps.update({'uuid': surfuuid})
 
         for argName, argValue in surfProps.items():
-            if any(argName.lower().startswith(v) for v in
-                    ['basefe']) and\
-                   raycing.is_valid_uuid(str(argValue)):
-                argFE = self.beamLine.fesDict.get(argValue)
-                if hasattr(argFE, 'name'):
-                    surfProps[argName] = argFE.name
+            refKind = raycing.ref_kind_for_arg(argName)
+            if refKind is not None:
+                surfProps[argName] = raycing.normalize_ref(
+                    argValue, self.beamLine, refKind, target='display')
         glowObj = getattr(self, 'blViewer', None)
         glWidget = getattr(glowObj, 'customGlWidget', None)
         surfViewer = InstanceInspector(self, surfProps, beamLine=self.beamLine,
@@ -1591,12 +1579,16 @@ class XrtQookBase(qt.QMainWindow):
         view.setRowHidden(child0.index().row(), parent.index(), True)
         return child0, child1
 
-    def addParam(self, parent, paramName, value, source=None, unit=None):
+    def addParam(self, parent, paramName, value, source=None, unit=None,
+                 editorHint=None):
         """Add a pair of Parameter-Value Items"""
         toolTip = None
         child0 = qt.QStandardItem(str(paramName))
         child0.setFlags(self.paramFlag)
         child1 = qt.QStandardItem()
+        if editorHint is not None:
+            child0.setData(editorHint, qt.EDITOR_HINT_ROLE)
+            child1.setData(editorHint, qt.EDITOR_HINT_ROLE)
         self.setParamItemValue(child1, paramName, value)
         if str(paramName) == 'name':
             ch1flag = self.paramFlag
@@ -1650,16 +1642,22 @@ class XrtQookBase(qt.QMainWindow):
         return str(value)
 
     def setParamItemValue(self, item, paramName, value):
-        rawValue = str(value)
-        item.setData(rawValue, qt.Qt.UserRole + 1)
-        item.setText(self.formatParamDisplay(paramName, value))
+        editorHint = item.data(qt.EDITOR_HINT_ROLE)
+        rawValue = raycing.serialize_editor_value(
+            value, editorHint, getattr(self, 'beamLine', None))
+        item.setData(rawValue, qt.RAW_VALUE_ROLE)
+        if isinstance(editorHint, dict) and editorHint.get('editor') == 'dict':
+            displayValue = rawValue
+        else:
+            displayValue = self.formatParamDisplay(paramName, value)
+        item.setText(displayValue)
         if item.text() != rawValue:
             item.setToolTip(rawValue)
         else:
             item.setToolTip('')
 
     def getParamItemValue(self, item):
-        rawValue = item.data(qt.Qt.UserRole + 1)
+        rawValue = item.data(qt.RAW_VALUE_ROLE)
         return str(rawValue) if rawValue is not None else str(item.text())
 
     def addProp(self, parent, propName):
@@ -1738,6 +1736,12 @@ class XrtQookBase(qt.QMainWindow):
                                                    argSpec[3]):
                                 if arg == 'bl':
                                     argVal = self.rootBLItem.text()
+                                editorHint = raycing.get_argument_editor_hint(
+                                    objRef, arg)
+                                if argVal is None and isinstance(
+                                        editorHint, dict) and\
+                                        'default' in editorHint:
+                                    argVal = editorHint['default']
                                 if arg not in uArgs and arg not in hpList:
                                     uArgs[arg] = argVal
 #                                    args.append(arg)
@@ -1907,7 +1911,8 @@ class XrtQookBase(qt.QMainWindow):
 #                        print(pyname, oldname)
                         self.iterateRename(
                                 self.rootMatItem, oldname, pyname,
-                                ['tlay', 'blay', 'coat', 'substrate'])
+                                ['tlay', 'blay', 'coat', 'substrate',
+                                 'materialsIndex'])
                         self.iterateRename(self.rootBLItem, oldname, pyname,
                                            ['material'])
                     elif item.model() is self.fesModel:
@@ -1956,13 +1961,51 @@ class XrtQookBase(qt.QMainWindow):
         signalsBlocked = model.signalsBlocked()
         model.blockSignals(True)
 
+        def replace_value(value):
+            if isinstance(value, dict):
+                newDict = OrderedDict()
+                changed = False
+                for key, itemValue in value.items():
+                    newValue, itemChanged = replace_value(itemValue)
+                    newDict[key] = newValue
+                    changed = changed or itemChanged
+                return dict(newDict), changed
+            if isinstance(value, list):
+                newList = []
+                changed = False
+                for itemValue in value:
+                    newValue, itemChanged = replace_value(itemValue)
+                    newList.append(newValue)
+                    changed = changed or itemChanged
+                return newList, changed
+            if isinstance(value, tuple):
+                newList, changed = replace_value(list(value))
+                return tuple(newList), changed
+            if str(value) == old_name:
+                return new_name, True
+            return value, False
+
         def recurse(item):
             for row in range(item.rowCount()):
                 argName = item.child(row, 0)
                 argValue = item.child(row, 1)
-                if argValue is not None and argValue.text() == old_name and\
-                        any([m in argName.text() for m in mask]):
-                    argValue.setText(new_name)
+                argNameText = str(argName.text())
+                if argValue is not None and\
+                        any([str(m).lower() in argNameText.lower()
+                             for m in mask]):
+                    rawValue = self.getParamItemValue(argValue)
+                    if rawValue == old_name:
+                        self.setParamItemValue(argValue, argNameText,
+                                               new_name)
+                    else:
+                        try:
+                            parsedValue = raycing.parametrize(rawValue)
+                        except Exception:
+                            parsedValue = rawValue
+                        newValue, changed = replace_value(parsedValue)
+                        if changed:
+                            self.setParamItemValue(argValue, argNameText,
+                                                   newValue)
                 recurse(item.child(row, 0))
         try:
             recurse(rootItem)
@@ -2199,7 +2242,8 @@ class XrtQookBase(qt.QMainWindow):
             pnItem = rootItem.child(pn, 0)
             itemDict = OrderedDict()
             if not pnItem.hasChildren():
-                outDict[str(pnItem.text())] = rootItem.child(pn, 1).text()
+                outDict[str(pnItem.text())] = self.getParamItemValue(
+                    rootItem.child(pn, 1))
                 continue
             for pnp in range(pnItem.rowCount()):
                 pltPropItem = pnItem.child(pnp, 0)
@@ -2207,12 +2251,13 @@ class XrtQookBase(qt.QMainWindow):
                     axDict = OrderedDict()
                     for axn in range(pltPropItem.rowCount()):
                         axPropName = pltPropItem.child(axn, 0).text()
-                        axPropValue = pltPropItem.child(axn, 1).text()
+                        axPropValue = self.getParamItemValue(
+                            pltPropItem.child(axn, 1))
                         axDict[axPropName] = axPropValue
                     itemDict[str(pltPropItem.text())] = axDict
                 else:
                     itemDict[str(pltPropItem.text())] = \
-                        str(pnItem.child(pnp, 1).text())
+                        self.getParamItemValue(pnItem.child(pnp, 1))
             outDict[str(pnItem.text())] = itemDict
         return outDict
 
@@ -2282,13 +2327,14 @@ class XrtQookBase(qt.QMainWindow):
                         else:
                             itemType = "object"
                         if int(child1.isEnabled()) == int(child0.isEnabled()):
-                            if not str(child1.text()).endswith('plot') and not\
-                                    str(child1.text()).startswith('Instance'):
+                            child1Value = self.getParamItemValue(child1)
+                            if not str(child1Value).endswith('plot') and not\
+                                    str(child1Value).startswith('Instance'):
                                 self.confText +=\
                                     '{0}<{1} type=\"{3}\">{2}</{1}>\n'.format(
                                         self.prefixtab,
                                         despace(str(child0.text())),
-                                        child1.text(),
+                                        child1Value,
                                         itemType)
                 elif flatModel:
                     self.confText +=\

--- a/xrt/gui/xrtQook/widgets/qookelements.py
+++ b/xrt/gui/xrtQook/widgets/qookelements.py
@@ -151,20 +151,12 @@ class XrtQookElements(XrtQookBase):
             if arg == 'uuid':
                 elementItem.setData(argVal, qt.Qt.UserRole)
                 continue
-            if arg in ['material', 'material2', 'tlayer', 'blayer', 'coating',
-                       'substrate']:
-                for iMat in range(self.rootMatItem.rowCount()):
-                    matItem = self.rootMatItem.child(iMat, 0)
-                    if str(matItem.data(qt.Qt.UserRole)) == str(argVal):
-                        argVal = str(matItem.text())
-                        break
-            elif arg in ['figureError', 'baseFE']:
-                for iFe in range(self.rootFEItem.rowCount()):
-                    feItem = self.rootFEItem.child(iFe, 0)
-                    if str(feItem.data(qt.Qt.UserRole)) == str(argVal):
-                        argVal = str(feItem.text())
-                        break
-            self.addParam(elprops, arg, argVal)
+            refKind = raycing.ref_kind_for_arg(arg)
+            if refKind is not None:
+                argVal = raycing.normalize_ref(
+                    argVal, self.beamLine, refKind, target='display')
+            editorHint = raycing.get_argument_editor_hint(obj, arg)
+            self.addParam(elprops, arg, argVal, editorHint=editorHint)
 
         if not isRoot:
             self.showDoc(elementItem.index())
@@ -235,7 +227,8 @@ class XrtQookElements(XrtQookBase):
         else:
             self.iterateRename(
                     self.rootMatItem, oldname, "None",
-                    ['tlay', 'blay', 'coat', 'substrate'])
+                    ['tlay', 'blay', 'coat', 'substrate',
+                     'materialsIndex'])
             self.iterateRename(self.rootBLItem, oldname, "None",
                                ['material'])
             item.model().invisibleRootItem().removeRow(item.index().row())


### PR DESCRIPTION
Adds the dictionary editor workflow for TXMMaterial.materialsIndex, and potentially other dict-like or sequence-like properties
A few small fixes, including
- Fix material rename propagation into matnamesToUUIDs.
- Prevent direct self-selection recursion in materialsIndex.
- Add figure-error surface export to .dat.
- Make imported figure-error placeholders preview-safe before a file is loaded.