### PR TITLE
Allow the main xrtQook window to become an active window if clicked

### DIFF
--- a/xrt/gui/xrtGlow/widgets/inspector.py
+++ b/xrt/gui/xrtGlow/widgets/inspector.py
@@ -46,6 +46,8 @@ class InstanceInspector(qt.QDialog):
             self.windowTitleStr += ' - Static Mode - View Only'
         self.setWindowTitle(self.windowTitleStr)
 
+        self.setWindowFlags(qt.Qt.WindowType.Window)
+
         self.model = qt.QStandardItemModel()
         self.modelRoot = self.model.invisibleRootItem()
         self.original_data = raycing.OrderedDict()


### PR DESCRIPTION
Fixes #277 

Prior if there are "View Properties" windows open, if you tried to click on the xrtQook window, it would not become the active window and you would be required to drag the other windows away to see it. 

Now, when you click on the xrtQook window it goes to the front of all tabs currently opened.