### PR TITLE
Beam concatenation with flux

### DIFF
--- a/tests/raycing/test_concatenate.py
+++ b/tests/raycing/test_concatenate.py
@@ -11,9 +11,9 @@ Created with xrtQook
 
 """
 
-import numpy as np
 import sys
-sys.path.append(r"C:\GitHub\xrt")
+import os, sys; sys.path.append(os.path.join('..', '..'))  # analysis:ignore
+
 import xrt.backends.raycing.sources as rsources
 import xrt.backends.raycing.screens as rscreens
 import xrt.backends.raycing.materials as rmats

--- a/tests/raycing/test_concatenate.py
+++ b/tests/raycing/test_concatenate.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+"""
+
+__author__ = "Konstantin Klementiev", "Roman Chernikov"
+__date__ = "2026-08-13"
+
+Created with xrtQook
+
+
+
+
+"""
+
+import numpy as np
+import sys
+sys.path.append(r"C:\GitHub\xrt")
+import xrt.backends.raycing.sources as rsources
+import xrt.backends.raycing.screens as rscreens
+import xrt.backends.raycing.materials as rmats
+import xrt.backends.raycing.materials.elemental as rmatsel
+import xrt.backends.raycing.materials.compounds as rmatsco
+import xrt.backends.raycing.materials.crystals as rmatscr
+import xrt.backends.raycing.oes as roes
+import xrt.backends.raycing.apertures as rapts
+import xrt.backends.raycing.figure_error as rfe
+import xrt.backends.raycing.run as rrun
+import xrt.backends.raycing as raycing
+import xrt.plotter as xrtplot
+import xrt.runner as xrtrun
+
+
+def build_beamline():
+    bl = raycing.BeamLine(
+        name=r"BeamLine")
+
+    bl.wiggler01 = rsources.Wiggler(
+        bl=bl,
+        name=r"wiggler01",
+        nrays=8e4,
+        n=10,
+#        uniformRayDensity=True,
+        xPrimeMax=1.5e-2,
+        zPrimeMax=2.5e-2,
+        center=[0.0, -3000.0, 0.0])
+
+    bl.wiggler02 = rsources.Wiggler(
+        bl=bl,
+        name=r"wiggler02",
+        nrays=5e4,
+        n=20,
+        xPrimeMax=1.5e-2,
+        zPrimeMax=2.5e-2,
+#        uniformRayDensity=True,
+        center=[0.0, 3000.0, 0.0])
+
+    bl.screen01 = rscreens.Screen(
+        bl=bl,
+        name=r"screen01")
+
+    return bl
+
+
+def run_process(bl):
+    wiggler01_global = bl.wiggler01.shine()
+
+    wiggler01_global.Jss *= 0.5
+    wiggler01_global.Jpp *= 0.5
+    wiggler01_global.Jsp *= 0.5
+
+    wiggler02_global = bl.wiggler02.shine()
+    w2_raw = rsources.Beam(copyFrom=wiggler02_global)
+#    w2_raw = wiggler02_global
+
+    wiggler02_global.concatenate(wiggler01_global)
+
+#    screen01_local = bl.screen01.expose(
+#        beam=bendingMagnet01_global)
+
+    outDict = {
+        'wiggler01_global': wiggler01_global,
+        'wiggler02_global': wiggler02_global,
+        'w2_raw': w2_raw,
+#        'screen01_local': screen01_local
+        }
+    return outDict
+
+
+rrun.run_process = run_process
+
+
+def define_plots():
+    plots = []
+
+    plot01 = xrtplot.XYCPlot(
+        beam=r"wiggler01_global",
+        xaxis=xrtplot.XYCAxis(
+            label=r"x"),
+        yaxis=xrtplot.XYCAxis(
+            label=r"z"),
+        caxis=xrtplot.XYCAxis(
+            label=r"energy",
+            unit=r"eV"),
+        title=r"plot01-wiggler01_global")
+    plots.append(plot01)
+
+    plot02 = xrtplot.XYCPlot(
+        beam=r"w2_raw",
+        xaxis=xrtplot.XYCAxis(
+            label=r"x"),
+        yaxis=xrtplot.XYCAxis(
+            label=r"z"),
+        caxis=xrtplot.XYCAxis(
+            label=r"energy",
+            unit=r"eV"),
+        title=r"plot01-wiggler02_global")
+    plots.append(plot02)
+
+    plot03 = xrtplot.XYCPlot(
+        beam=r"wiggler02_global",
+        xaxis=xrtplot.XYCAxis(
+            label=r"x"),
+        yaxis=xrtplot.XYCAxis(
+            label=r"z"),
+        caxis=xrtplot.XYCAxis(
+            label=r"energy",
+            unit=r"eV"),
+        title=r"plot03-Sum")
+    plots.append(plot03)
+
+    return plots
+
+
+def main():
+    BeamLine = build_beamline()
+#    E0 = 0.5 * (BeamLine.bendingMagnet01.eMin +
+#                BeamLine.bendingMagnet01.eMax)
+#    BeamLine.alignE=E0
+    plots = define_plots()
+    xrtrun.run_ray_tracing(
+        plots=plots,
+        repeats=1,
+        backend=r"raycing",
+        beamLine=BeamLine)
+    i1 = plots[0].flux
+    i2 = plots[1].flux
+    i3 = plots[2].flux
+
+    print(f"W1 flux: {i1:.4g}, W2 flux: {i2:.4g}")
+    print(f"W1+W2 from plot: {i3:.4g}, W1+W2 sum: {i1+i2:.4g}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/raycing/test_concatenate.py
+++ b/tests/raycing/test_concatenate.py
@@ -33,25 +33,53 @@ def build_beamline():
     bl = raycing.BeamLine(
         name=r"BeamLine")
 
-    bl.wiggler01 = rsources.Wiggler(
-        bl=bl,
-        name=r"wiggler01",
-        nrays=8e4,
-        n=10,
-#        uniformRayDensity=True,
-        xPrimeMax=1.5e-2,
-        zPrimeMax=2.5e-2,
-        center=[0.0, -3000.0, 0.0])
+#    bl.wiggler01 = rsources.Wiggler(
+#        bl=bl,
+#        name=r"wiggler01",
+#        nrays=8e4,
+#        n=10,
+##        uniformRayDensity=True,
+#        xPrimeMax=1.5e-2,
+#        zPrimeMax=2.5e-2,
+#        center=[0.0, -3000.0, 0.0])
+#
+#    bl.wiggler02 = rsources.Wiggler(
+#        bl=bl,
+#        name=r"wiggler02",
+#        nrays=5e4,
+#        n=20,
+#        xPrimeMax=1.5e-2,
+#        zPrimeMax=2.5e-2,
+##        uniformRayDensity=True,
+#        center=[0.0, 3000.0, 0.0])
 
-    bl.wiggler02 = rsources.Wiggler(
-        bl=bl,
-        name=r"wiggler02",
-        nrays=5e4,
-        n=20,
-        xPrimeMax=1.5e-2,
-        zPrimeMax=2.5e-2,
-#        uniformRayDensity=True,
-        center=[0.0, 3000.0, 0.0])
+    bl.wiggler01 = rsources.GeometricSource(
+            bl=bl,
+            nrays=8e4,
+            totalFlux=3e7,
+            disty='normal',
+            dy=0.1,
+            dx=0.1,
+            dz=0.1,
+            dxprime=0.001,
+            dzprime=0.001,
+            uniformRayDensity=True,
+            center=[0.0, -3000.0, 0.0]
+            )
+
+    bl.wiggler02 = rsources.GeometricSource(
+            bl=bl,
+            nrays=1e4,
+            totalFlux=5e6,
+            disty='normal',
+            dy=0.1,
+            uniformRayDensity=True,
+            dx=0.1,
+            dz=0.1,
+            dxprime=0.001,
+            dzprime=0.001,
+            center=[0.0, 3000.0, 0.0]
+            )
 
     bl.screen01 = rscreens.Screen(
         bl=bl,

--- a/xrt/backends/raycing/__init__.py
+++ b/xrt/backends/raycing/__init__.py
@@ -438,31 +438,36 @@ def get_output(plot, beamsReturnedBy_run_process):
         else:
             raise ValueError('cannot find data for cData!')
 
+        srcWt = nrays * beam.sourceWeight if hasattr(beam, 'sourceWeight')\
+            else 1.
+
         if plot.fluxKind.startswith('power'):
-            intensity = ((beam.Jss + beam.Jpp) *
-                         beam.E * beam.seededI / beam.seeded * SIE0)
+            intensity = (beam.Jss + beam.Jpp) * beam.E * SIE0 * srcWt
+#            intensity = ((beam.Jss + beam.Jpp) *
+#                         beam.E * beam.seededI / beam.seeded * SIE0)
 #            intensity = ((beam.Jss + beam.Jpp) *
 #                         beam.E * beam.accepted / beam.seeded * SIE0)
         elif plot.fluxKind.startswith('s'):
-            intensity = beam.Jss
+            intensity = beam.Jss * srcWt
         elif plot.fluxKind.startswith('p'):
-            intensity = beam.Jpp
+            intensity = beam.Jpp * srcWt
         elif plot.fluxKind.startswith('+/-45'):
-            intensity = 2*beam.Jsp.real
+            intensity = 2*beam.Jsp.real * srcWt
         elif plot.fluxKind.startswith('left-right'):
-            intensity = 2*beam.Jsp.imag
+            intensity = 2*beam.Jsp.imag * srcWt
         elif plot.fluxKind.startswith('E'):
+            sqrtWt = np.sqrt(srcWt)
             if plot.fluxKind.startswith('Es'):
-                intensity = beam.Es
-                flux = beam.Jss
+                intensity = beam.Es * sqrtWt
+                flux = beam.Jss * srcWt
             elif plot.fluxKind.startswith('Ep'):
-                intensity = beam.Ep
-                flux = beam.Jpp
+                intensity = beam.Ep* sqrtWt
+                flux = beam.Jpp * srcWt
             else:
-                intensity = beam.Es + beam.Ep
-                flux = beam.Jss + beam.Jpp
+                intensity = (beam.Es + beam.Ep) * sqrtWt
+                flux = (beam.Jss + beam.Jpp) * srcWt
         else:
-            intensity = beam.Jss + beam.Jpp
+            intensity = (beam.Jss + beam.Jpp) * srcWt
 
         if not plot.fluxKind.startswith('E'):
             flux = intensity

--- a/xrt/backends/raycing/sources/__init__.py
+++ b/xrt/backends/raycing/sources/__init__.py
@@ -86,33 +86,157 @@ See the example :ref:`Undulator radiation through rectangular aperture
 Absolute flux and power
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Geometric sources do not provide an absolute physical source
-normalization; their plot values are relative intensities or weighted
-ray counts.
+Raycing plots calculate flux and power from the ray intensities already
+carried by the beam. For total flux, the per-ray intensity is the trace of the
+coherency matrix,
 
-For synchrotron sources, both Monte Carlo strategies use::
+.. math::
 
-    sourceNormalization = seededI / seeded
+    I_i = J_{ss,i} + J_{pp,i}.
 
-With rejection sampling, ``seededI / seeded`` is the sampled phase-space
-volume multiplied by the mean calculated intensity of the trial samples.
-Accepted rays have unit initial total intensity, and their density is
-proportional to the source intensity.
+For power plots, the same ray intensity is multiplied by photon energy and by
+the joule-per-eV conversion factor,
 
-With uniform ray density, ``seededI / seeded`` is the sampled phase-space
-volume. All trial samples are accepted, and the calculated source
-intensity is carried by their ray weights.
+.. math::
 
-Let *rayIntensity* be the per-ray intensity after beamline propagation.
-For the rays selected by a plot, absolute flux and power are::
+    P_i = I_i E_i e,
 
-    flux = (mean(rayIntensity) *
-            sourceNormalization)
+where :math:`E_i` is in eV.
 
-    power = (mean(rayIntensity * photonEnergy) *
-             sourceNormalization * joulesPerElectronvolt)
+If a beam has ``sourceWeight``, raycing treats it as the source normalization
+represented by the ray. For a run with :math:`N` rays, the histogram receives
 
-Here, *photonEnergy* is in eV. Flux is reported in ph/s and power in W.
+.. math::
+
+    N I_i w_i
+
+for flux, or
+
+.. math::
+
+    N I_i E_i e w_i
+
+for power, where :math:`w_i` is ``beam.sourceWeight``. The reported plot value
+is divided by the accumulated number of rays, so for one run this is equivalent
+to
+
+.. math::
+
+    \Phi = \sum_i I_i w_i,
+
+and
+
+.. math::
+
+    P = \sum_i I_i E_i e w_i.
+
+The same logic applies to the selected subset of rays in a plot, and to the
+other ``fluxKind`` values with the corresponding coherency-matrix component in
+place of :math:`J_{ss}+J_{pp}`.
+
+For synchrotron sources, ``sourceWeight`` is determined by the sampled source
+phase-space volume. In the usual far-field ray source this volume is
+
+.. math::
+
+    V = (E_{\max} - E_{\min})
+        (\Theta_{\max} - \Theta_{\min})
+        (\Psi_{\max} - \Psi_{\min}).
+
+The calculated source intensity at a sampled point is denoted below as
+:math:`F_i`.
+
+With rejection sampling, trial points are sampled uniformly in this volume.
+Only a subset is accepted, and the accepted rays have unit initial total
+intensity. If :math:`M` trial points were tested, raycing estimates the source
+normalization as
+
+.. math::
+
+    C = {V \over M}\sum_{k=1}^{M} F_k.
+
+If :math:`N` rays are accepted and propagated, each propagated ray gets
+
+.. math::
+
+    w_i = {C \over N}.
+
+Then, for any downstream transmission or selection factor :math:`T_i`,
+
+.. math::
+
+    \Phi = \sum_i T_i w_i
+          = {C \over N}\sum_i T_i
+          \rightarrow \int_V T(\xi) F(\xi)\,d\xi.
+
+With uniform ray density, all sampled points are used and the calculated source
+intensity is carried by the ray intensities themselves. Raycing stores
+
+.. math::
+
+    w_i = \frac{V}{N}.
+
+The plot flux is then
+
+.. math::
+
+    \Phi = \sum_i T_i F_i {V \over N}
+          \rightarrow \int_V T(\xi) F(\xi)\,d\xi.
+
+Thus both sampling modes use the same plot-side calculation; they differ only
+in where the source intensity is represented: in ray density for rejection
+sampling, or in ray weights for uniform ray density. Power is calculated by the
+same estimator with the additional factor :math:`E_i e`.
+
+For geometric sources, there is no calculated synchrotron intensity map. If
+``totalFlux`` is supplied, raycing normalizes the generated beam directly. Let
+
+.. math::
+
+    I_i^0 = J_{ss,i}^0 + J_{pp,i}^0
+
+be the initial ray intensity after polarization and any source-specific
+amplitude weighting. Raycing sets
+
+.. math::
+
+    w_i = \frac{\Phi_0}{\sum_j I_j^0},
+
+where :math:`\Phi_0` is ``totalFlux``. Therefore the source beam satisfies
+
+.. math::
+
+    \sum_i I_i^0 w_i = \Phi_0.
+
+After propagation, the plotted flux is the same weighted sum of the remaining
+ray intensities,
+
+.. math::
+
+    \Phi = \sum_i I_i w_i,
+
+and power is
+
+.. math::
+
+    P = \sum_i I_i E_i e w_i.
+
+This also works for geometric sources generated with uniform ray density,
+because the normalization uses the actual initial ray intensities.
+
+The normalization is local to each ray, so it survives beam concatenation. If
+two beams are concatenated, their ray arrays and their ``sourceWeight`` values
+are concatenated together. The combined plot value is therefore
+
+.. math::
+
+    \Phi_{A+B}
+      = \sum_{i \in A} I_i w_i + \sum_{j \in B} I_j w_j
+      = \Phi_A + \Phi_B,
+
+and likewise for power. This is useful, for example, for adding independent
+sources such as canted or serial insertion devices, or an insertion device and
+a bending magnet. The addition is an incoherent sum of ray intensities.
 
 Grid sampling does not use these beam counters. Its absolute flux and
 power are obtained by directly integrating the intensity map, or the

--- a/xrt/backends/raycing/sources/__init__.py
+++ b/xrt/backends/raycing/sources/__init__.py
@@ -135,7 +135,7 @@ other ``fluxKind`` values with the corresponding coherency-matrix component in
 place of :math:`J_{ss}+J_{pp}`.
 
 For synchrotron sources, ``sourceWeight`` is determined by the sampled source
-phase-space volume. In the usual far-field ray source this volume is
+bounding volume. In the usual far-field ray source this volume is
 
 .. math::
 

--- a/xrt/backends/raycing/sources/beams.py
+++ b/xrt/backends/raycing/sources/beams.py
@@ -102,7 +102,7 @@ class Beam(object):
                    'phi', 'r', 'theta', 'order', 'accepted',
                    'acceptedE', 'seeded', 'seededI', 'Es', 'Ep',
                    # 'area',
-                   'nRefl']
+                   'nRefl', 'sourceWeight']
 
     def __init__(self, nrays=raycing.nrays, copyFrom=None, forceState=False,
                  withNumberOfReflections=False, withAmplitudes=False,
@@ -230,6 +230,8 @@ class Beam(object):
     def concatenate(self, beam):
         """Adds *beam* to *self*. Useful when more than one source is
         presented."""
+        nself = len(self.x)
+
         self.state = np.concatenate((self.state, beam.state))
         self.x = np.concatenate((self.x, beam.x))
         self.y = np.concatenate((self.y, beam.y))
@@ -242,6 +244,7 @@ class Beam(object):
         self.Jss = np.concatenate((self.Jss, beam.Jss))
         self.Jpp = np.concatenate((self.Jpp, beam.Jpp))
         self.Jsp = np.concatenate((self.Jsp, beam.Jsp))
+
         if hasattr(self, 'nRefl') and hasattr(beam, 'nRefl'):
             self.nRefl = np.concatenate((self.nRefl, beam.nRefl))
         if hasattr(self, 'elevationD') and hasattr(beam, 'elevationD'):
@@ -263,14 +266,29 @@ class Beam(object):
             self.theta = np.concatenate((self.theta, beam.theta))
         if hasattr(self, 'order') and hasattr(beam, 'order'):
             self.order = np.concatenate((self.order, beam.order))
-        if hasattr(self, 'accepted') and hasattr(beam, 'accepted'):
-            seeded = self.seeded + beam.seeded
-            self.accepted = (self.accepted / self.seeded +
-                             beam.accepted / beam.seeded) * seeded
-            self.acceptedE = (self.acceptedE / self.seeded +
-                              beam.acceptedE / beam.seeded) * seeded
-            self.seeded = seeded
-            self.seededI = self.seededI + beam.seededI
+        if hasattr(self, 'sourceWeight') and hasattr(beam, 'sourceWeight'):
+            nbeam = len(beam.x)
+            if np.ndim(self.sourceWeight) == 0 and\
+                    np.ndim(beam.sourceWeight) == 0:
+                if self.sourceWeight == beam.sourceWeight:
+                    pass
+                else:
+                    self.sourceWeight = np.concatenate((
+                        np.full(nself, self.sourceWeight),
+                        np.full(nbeam, beam.sourceWeight),
+                    ))
+            else:
+                self.sourceWeight = np.concatenate((
+                    np.broadcast_to(self.sourceWeight, nself),
+                    np.broadcast_to(beam.sourceWeight, nbeam),
+                ))
+#            seeded = self.seeded + beam.seeded
+#            self.accepted = (self.accepted / self.seeded +
+#                             beam.accepted / beam.seeded) * seeded
+#            self.acceptedE = (self.acceptedE / self.seeded +
+#                              beam.acceptedE / beam.seeded) * seeded
+#            self.seeded = seeded
+#            self.seededI = self.seededI + beam.seededI
         if hasattr(self, 'Es') and hasattr(beam, 'Es'):
             self.Es = np.concatenate((self.Es, beam.Es))
             self.Ep = np.concatenate((self.Ep, beam.Ep))
@@ -308,6 +326,8 @@ class Beam(object):
         if hasattr(self, 'Es'):
             self.Es = self.Es[indarr]
             self.Ep = self.Ep[indarr]
+        if hasattr(self, 'sourceWeight') and np.ndim(self.sourceWeight) > 0:
+            self.sourceWeight = self.sourceWeight[indarr]
         return self
 
     def replace_by_index(self, indarr, beam):

--- a/xrt/backends/raycing/sources/geoms.py
+++ b/xrt/backends/raycing/sources/geoms.py
@@ -179,6 +179,17 @@ def make_polarization(polarization, bo, nrays=raycing.nrays):
         _fill_linear(angle)
 
 
+def make_flux_normalization(tFlux, beam):
+    if np.isscalar(tFlux) and tFlux > 0:
+        intensitySum = (beam.Jss + beam.Jpp).sum()
+        if intensitySum > 0:
+            beam.sourceWeight = tFlux / intensitySum
+            beam.seeded = len(beam.E)
+            beam.seededI = 1.
+            beam.accepted = 1.
+            beam.acceptedE = 1.
+
+
 class GeometricSource(object):
     """Implements a geometric source - a source with the ray origin,
     divergence and energy sampled with the given distribution laws."""
@@ -481,21 +492,7 @@ class GeometricSource(object):
             self._apply_distribution(bo.a, self.distxprime, self.dxprime, bo)
             self._apply_distribution(bo.c, self.distzprime, self.dzprime, bo)
 
-        if np.isscalar(self.totalFlux) and self.totalFlux > 0:
-            if self.uniformRayDensity:
-                bo.sourceWeight = self.totalFlux / self.nrays
-                bo.seeded = self.nrays
-                bo.seededI = 1.
-                bo.accepted = 1.
-                bo.acceptedE = 1.
-            else:
-                intensitySum = (bo.Jss + bo.Jpp).sum()
-                if intensitySum > 0:
-                    bo.sourceWeight = self.totalFlux / intensitySum
-                    bo.seeded = self.nrays
-                    bo.seededI = 1.
-                    bo.accepted = 1.
-                    bo.acceptedE = 1.
+        make_flux_normalization(self.totalFlux, bo)
 
 # normalize (a,b,c):
         ac = bo.a**2 + bo.c**2
@@ -617,6 +614,7 @@ class GaussianBeam(object):
         self.pitch = raycing.auto_units_angle(pitch)
         self.roll = raycing.auto_units_angle(roll)
         self.yaw = raycing.auto_units_angle(yaw)
+        self.totalFlux = kwargs.get('totalFlux')
 
     center = raycing.center_property()
 
@@ -770,6 +768,8 @@ class GaussianBeam(object):
         wave.Jss *= amp2
         wave.Jpp *= amp2
         wave.Jsp *= amp2
+
+        make_flux_normalization(self.totalFlux, wave)
 
         wave.a[:] = wave.xDiffr
         wave.c[:] = wave.zDiffr
@@ -930,6 +930,7 @@ class MeshSource(object):
                 bl.oenamesToUUIDs[self.name] = self.uuid
 
         self.polarization = polarization
+        self.totalFlux = kwargs.get('totalFlux')
 
     center = raycing.center_property()
 
@@ -1029,6 +1030,7 @@ class MeshSource(object):
             np.linspace(self.minxprime, self.maxxprime, self.nx),
             np.linspace(self.minzprime, self.maxzprime, self.nz))
         zz = np.flipud(zz)
+
         bo.a[int(self.withCentralRay):] = xx.flatten()
         bo.c[int(self.withCentralRay):] = zz.flatten()
 # normalize (a,b,c):
@@ -1040,6 +1042,7 @@ class MeshSource(object):
             bo.E[:] = make_energy(self.distE, self.energies, self.nrays,
                                   energyWeights=self.energyWeights)
         make_polarization(self.polarization, bo, self.nrays)
+        make_flux_normalization(self.totalFlux, bo)
         if toGlobal:  # in global coordinate system:
             raycing.virgin_local_to_global(self.bl, bo, self.center)
         raycing.append_to_flow(self.shine, [bo],
@@ -1132,6 +1135,7 @@ class CollimatedMeshSource(object):
                 bl.oenamesToUUIDs[self.name] = self.uuid
 
         self.polarization = polarization
+        self.totalFlux = kwargs.get('totalFlux')
 
     center = raycing.center_property()
 
@@ -1203,6 +1207,7 @@ class CollimatedMeshSource(object):
             bo.E[:] = make_energy(self.distE, self.energies, self.nrays,
                                   energyWeights=self.energyWeights)
         make_polarization(self.polarization, bo, self.nrays)
+        make_flux_normalization(self.totalFlux, bo)
         if toGlobal:  # in global coordinate system:
             raycing.virgin_local_to_global(self.bl, bo, self.center)
         raycing.append_to_flow(self.shine, [bo],

--- a/xrt/backends/raycing/sources/geoms.py
+++ b/xrt/backends/raycing/sources/geoms.py
@@ -251,8 +251,9 @@ class GeometricSource(object):
             calculations. False is usual for ray-tracing. This parameter
             only affects normal distributions, as for flat and annulus
             distributions the density is already uniform. If you set it True,
-            the size parameter (*dx* or *dz*) must be given as
-            (sigma, cut_limit).
+            the size parameter (*dx* or *dz*) will use a +/-5 sigma sampling
+            interval. Use (sigma, cut_limit) sequence to set this half-width
+            explicitly.
 
             See :ref:`absolute-flux-and-power` for how ray density and ray
             weights affect plot intensity and normalization.
@@ -305,6 +306,7 @@ class GeometricSource(object):
         self._pitch = raycing.auto_units_angle(pitch)
         self._roll = raycing.auto_units_angle(roll)
         self._yaw = raycing.auto_units_angle(yaw)
+        self.totalFlux = kwargs.get('totalFlux')
 
     center = raycing.center_property()
 
@@ -351,11 +353,19 @@ class GeometricSource(object):
     def _apply_distribution(self, axis, distaxis, daxis, bo=None):
         if distaxis == 'normal':
             if self.uniformRayDensity:
-                if not isinstance(daxis, (list, tuple)):
-                    raise ValueError("Wrong distribution size!")
-                axis[:] = np.random.uniform(-daxis[1], daxis[1], self.nrays)
-                amp = np.exp(-axis**2 / daxis[0]**2 / 2) /\
-                    PI2**0.5 / daxis[0] * 2 * daxis[1]
+                daxisArr = np.atleast_1d(daxis)
+                if len(daxisArr) < 2:
+                    sigma = daxisArr[0]
+                    cutLim = 5 * abs(sigma)
+                else:
+                    sigma = daxisArr[0]
+                    cutLim = daxisArr[-1]
+                axis[:] = np.random.uniform(-cutLim, cutLim, self.nrays)
+#                if not isinstance(daxis, (list, tuple)):
+#                    raise ValueError("Wrong distribution size!")
+#                axis[:] = np.random.uniform(-daxis[-1], daxis[-1], self.nrays)
+                amp = np.exp(-axis**2 / sigma**2 / 2) /\
+                    PI2**0.5 / sigma * 2 * cutLim
                 bo.Jss *= amp
                 bo.Jpp *= amp
                 bo.Jsp *= amp
@@ -435,7 +445,7 @@ class GeometricSource(object):
 
         make_polarization(self.polarization, bo, self.nrays)
 # in local coordinate system:
-        self._apply_distribution(bo.y, self.disty, self.dy)
+        self._apply_distribution(bo.y, self.disty, self.dy, bo)
 
         isAnnulus = False
         if (self.distx == 'annulus') or (self.distz == 'annulus'):
@@ -468,8 +478,24 @@ class GeometricSource(object):
         if isAnnulus:
             self._set_annulus(bo.a, bo.c, rMin, rMax, phiMin, phiMax)
         else:
-            self._apply_distribution(bo.a, self.distxprime, self.dxprime)
-            self._apply_distribution(bo.c, self.distzprime, self.dzprime)
+            self._apply_distribution(bo.a, self.distxprime, self.dxprime, bo)
+            self._apply_distribution(bo.c, self.distzprime, self.dzprime, bo)
+
+        if np.isscalar(self.totalFlux) and self.totalFlux > 0:
+            if self.uniformRayDensity:
+                bo.sourceWeight = self.totalFlux / self.nrays
+                bo.seeded = self.nrays
+                bo.seededI = 1.
+                bo.accepted = 1.
+                bo.acceptedE = 1.
+            else:
+                intensitySum = (bo.Jss + bo.Jpp).sum()
+                if intensitySum > 0:
+                    bo.sourceWeight = self.totalFlux / intensitySum
+                    bo.seeded = self.nrays
+                    bo.seededI = 1.
+                    bo.accepted = 1.
+                    bo.acceptedE = 1.
 
 # normalize (a,b,c):
         ac = bo.a**2 + bo.c**2

--- a/xrt/backends/raycing/sources/geoms.py
+++ b/xrt/backends/raycing/sources/geoms.py
@@ -200,7 +200,8 @@ class GeometricSource(object):
         distxprime='normal', dxprime=1e-3, distzprime='normal', dzprime=1e-4,
         distE='lines', energies=(defaultEnergy,), energyWeights=None,
         polarization='horizontal', filamentBeam=False,
-            uniformRayDensity=False, pitch=0, roll=0, yaw=0, **kwargs):
+        uniformRayDensity=False, pitch=0, roll=0, yaw=0, totalFlux=None,
+            **kwargs):
         """
         *bl*: instance of :class:`~xrt.backends.raycing.BeamLine`
 
@@ -272,6 +273,11 @@ class GeometricSource(object):
         *pitch*, *roll*, *yaw*: float
             rotation angles around x, y and z axes. Useful for canted sources.
 
+        *totalFlux*: float or None
+            Absolute source flux in ph/s to use for source normalization.
+            The normalization is preserved during propagation and beam
+            concatenation. If None, plot values remain relative intensities or
+            weighted ray counts.
 
         """
         self.bl = bl
@@ -317,7 +323,7 @@ class GeometricSource(object):
         self._pitch = raycing.auto_units_angle(pitch)
         self._roll = raycing.auto_units_angle(roll)
         self._yaw = raycing.auto_units_angle(yaw)
-        self.totalFlux = kwargs.get('totalFlux')
+        self.totalFlux = totalFlux
 
     center = raycing.center_property()
 
@@ -538,7 +544,8 @@ class GaussianBeam(object):
     def __init__(
         self, bl=None, name='', center=(0, 0, 0), w0=0.1,
         distE='lines', energies=(defaultEnergy,), energyWeights=None,
-            polarization='horizontal', pitch=0, roll=0, yaw=0, **kwargs):
+        polarization='horizontal', pitch=0, roll=0, yaw=0, totalFlux=None,
+            **kwargs):
         """
         *bl*: instance of :class:`~xrt.backends.raycing.BeamLine`
 
@@ -577,6 +584,11 @@ class GaussianBeam(object):
         *pitch*, *roll*, *yaw*: float
             rotation angles around x, y and z axes. Useful for canted sources.
 
+        *totalFlux*: float or None
+            Absolute source flux in ph/s to use for source normalization.
+            The normalization is preserved during propagation and beam
+            concatenation. If None, plot values remain relative intensities or
+            weighted ray counts.
 
         """
         self.bl = bl
@@ -614,7 +626,7 @@ class GaussianBeam(object):
         self.pitch = raycing.auto_units_angle(pitch)
         self.roll = raycing.auto_units_angle(roll)
         self.yaw = raycing.auto_units_angle(yaw)
-        self.totalFlux = kwargs.get('totalFlux')
+        self.totalFlux = totalFlux
 
     center = raycing.center_property()
 
@@ -849,7 +861,7 @@ class MeshSource(object):
         minzprime=-1e-4, maxzprime=1e-4, nx=11, nz=11,
         distE='lines', energies=(defaultEnergy,), energyWeights=None,
         polarization='horizontal', withCentralRay=True,
-            autoAppendToBL=False, **kwargs):
+            autoAppendToBL=False, totalFlux=None, **kwargs):
         """
         *bl*: instance of :class:`~xrt.backends.raycing.BeamLine`
 
@@ -894,6 +906,12 @@ class MeshSource(object):
             if True, the source is added to the list of beamline sources.
             Otherwise the user must manually start it with :meth:`shine`.
 
+        *totalFlux*: float or None
+            Absolute source flux in ph/s to use for source normalization.
+            The normalization is preserved during propagation and beam
+            concatenation. If None, plot values remain relative intensities or
+            weighted ray counts.
+
         """
         self.bl = bl
         if autoAppendToBL:
@@ -930,7 +948,7 @@ class MeshSource(object):
                 bl.oenamesToUUIDs[self.name] = self.uuid
 
         self.polarization = polarization
-        self.totalFlux = kwargs.get('totalFlux')
+        self.totalFlux = totalFlux
 
     center = raycing.center_property()
 
@@ -1100,7 +1118,7 @@ class CollimatedMeshSource(object):
             dx=1., dz=1., nx=11, nz=11,
             distE='lines', energies=(defaultEnergy,), energyWeights=None,
             polarization='horizontal', withCentralRay=True,
-            autoAppendToBL=False, **kwargs):
+            autoAppendToBL=False, totalFlux=None, **kwargs):
 
         self.bl = bl
         if autoAppendToBL:
@@ -1135,7 +1153,7 @@ class CollimatedMeshSource(object):
                 bl.oenamesToUUIDs[self.name] = self.uuid
 
         self.polarization = polarization
-        self.totalFlux = kwargs.get('totalFlux')
+        self.totalFlux = totalFlux
 
     center = raycing.center_property()
 

--- a/xrt/backends/raycing/sources/sybase.py
+++ b/xrt/backends/raycing/sources/sybase.py
@@ -403,8 +403,8 @@ class SourceBase:
         xPrimeMaxVal = self._xPrimeMax
 
         if hasattr(self, '_xPrimeMaxAutoReduce') and self._xPrimeMaxAutoReduce:
-            if all([hasattr(self, x) for x in ['_Ky', '_gamma']]):
-                K0 = self.Ky if abs(self.Ky) > 0 else 2.
+            if all([hasattr(self, x) for x in ['_Ky', 'gamma']]):
+                K0 = self._Ky if abs(self._Ky) > 0 else 2.
                 xPrimeMaxTmp = K0 / self.gamma
                 if abs(self._xPrimeMax) > abs(xPrimeMaxTmp):
                     print("Reducing xPrimeMax from {0} down to {1} mrad".format(
@@ -1651,8 +1651,10 @@ class IntegratedSource(SourceBase):
 
             if self.uniformRayDensity:
                 seededI += mcRays * self.xzE
+                sourceWeight = self.xzE
             else:
                 seededI += Intensity.sum() * self.xzE
+                sourceWeight = seededI / seeded
             tmp_max = np.max(Intensity)
 
             if tmp_max > self.Imax:
@@ -1780,6 +1782,8 @@ class IntegratedSource(SourceBase):
             bo.acceptedE = bo.E.sum() * self.fluxConst * SIE0
             bo.seeded = seeded
             bo.seededI = seededI
+            nnorm = self.nrays if wave is None else len(wave.a)
+            bo.sourceWeight = sourceWeight / nnorm
 
             if raycing._VERBOSITY_ > 0:
                 sys.stdout.flush()

--- a/xrt/backends/raycing/sources/synchr.py
+++ b/xrt/backends/raycing/sources/synchr.py
@@ -199,7 +199,8 @@ class BendingMagnet(SourceBase):
 
         w_cr = 1.5 * gamma2 * self.B * SIE0 / SIM0
         if self.isMPW:
-            w_cr *= np.sin(np.arccos(ddtheta * gamma / self.K))
+            thetaArg = ddtheta * gamma / self.K
+            w_cr *= np.sqrt(np.clip(1. - thetaArg**2, 0., None))
         w_cr = np.where(np.isfinite(w_cr), w_cr, 0.)
 
         gammapsi = gamma * ddpsi
@@ -280,8 +281,10 @@ class BendingMagnet(SourceBase):
                     sourceSIGMAz = self.dz
                     rTheta0 = np.random.random_sample() *\
                         (self.Theta_max - self.Theta_min) + self.Theta_min
+                    thetaArg = np.clip(rTheta0 * self.gamma / self.K,
+                                       -1., 1.)
                     ryNp = 0.5 * self.L0 *\
-                        (np.arccos(rTheta0 * self.gamma / self.K) / PI) +\
+                        (np.arccos(thetaArg) / PI) +\
                         0.5 * self.L0 *\
                         np.random.random_integers(0, int(2*self.Np - 1))
                     rY = ryNp - 0.5*self.L0*self.Np
@@ -339,8 +342,10 @@ class BendingMagnet(SourceBase):
 
             if self.uniformRayDensity:
                 seededI += self.nrays * self.xzE
+                sourceWeight = self.xzE
             else:
                 seededI += Intensity.sum() * self.xzE
+                sourceWeight = seededI / seeded
 
             tmp_max = np.max(Intensity)
             if tmp_max > self.Imax:
@@ -403,7 +408,8 @@ class BendingMagnet(SourceBase):
                     bot.x[:] = rX
                     bot.y[:] = rY
                 else:
-                    bot.y[:] = ((np.arccos(Theta0*self.gamma/self.K) / PI) +
+                    thetaArg = np.clip(Theta0*self.gamma/self.K, -1., 1.)
+                    bot.y[:] = ((np.arccos(thetaArg) / PI) +
                                 np.random.randint(
                                     -int(self.Np), int(self.Np), npassed) -
                                 0.5) * 0.5 * self.L0
@@ -471,6 +477,7 @@ class BendingMagnet(SourceBase):
             bo.acceptedE = bo.E.sum() * self.fluxConst * SIE0
             bo.seeded = seeded
             bo.seededI = seededI
+            bo.sourceWeight = sourceWeight / self.nrays
 
         if length > self.nrays and not self.filamentBeam:
             bo.filter_by_index(slice(0, np.int64(self.nrays)))

--- a/xrt/plotter.py
+++ b/xrt/plotter.py
@@ -853,7 +853,7 @@ class XYCPlot(object):
             normalized to absolute flux and power.
 
         *fluxUnit*: 'auto' or None
-            If a synchrotron source is used and *fluxUnit* is 'auto', the
+            If source normalization is provided and *fluxUnit* is 'auto', the
             flux will be displayed as 'ph/s' or 'W' (if *fluxKind* == 'power').
             Otherwise the flux is a unitless number of rays times
             transmittivity | reflectivity.

--- a/xrt/plotter.py
+++ b/xrt/plotter.py
@@ -1905,11 +1905,10 @@ class XYCPlot(object):
 #        return r"{0}$\cdot$10$^{{{1}}}$".format(f_SF, power)
 
     def _get_flux(self):
-        self.flux = float(self.intensity) / self.nRaysAll *\
-            self.nRaysSeededI / self.nRaysSeeded
+        self.flux = float(self.intensity) / self.nRaysAll
 
     def _get_power(self):
-        self.power = self.intensity / self.nRaysAll
+        self.power = float(self.intensity) / self.nRaysAll
 
     def plot_plots(self):
         """


### PR DESCRIPTION
Flux normalization constants are now propagated from the source to each ray in the beam to calculate flux value after beam concatenation.
Added docstrings explaining the flux/power calculation approach.